### PR TITLE
Collect Fields into Field Objects

### DIFF
--- a/src/coders/byte-packets.js
+++ b/src/coders/byte-packets.js
@@ -1,6 +1,6 @@
 class Packet {
-    constructor (uint8 = new Uint8Array(this.size), offset = 0) {
-        this.uint8 = uint8;
+    constructor (uint8a = new Uint8Array(this.size), offset = 0) {
+        this.uint8a = uint8a;
         this.offset = offset;
     }
 

--- a/src/coders/byte-primitives.js
+++ b/src/coders/byte-primitives.js
@@ -36,11 +36,11 @@ class BytePrimitive {
 
         return {
             get () {
-                return _this.read(this.uint8, position + this.offset);
+                return _this.read(this.uint8a, position + this.offset);
             },
 
             set (value) {
-                return _this.write(this.uint8, position + this.offset, value);
+                return _this.write(this.uint8a, position + this.offset, value);
             },
 
             enumerable: true
@@ -50,11 +50,11 @@ class BytePrimitive {
 
 const Uint8 = new BytePrimitive({
     size: 1,
-    read (uint8, position) {
-        return uint8[position];
+    read (uint8a, position) {
+        return uint8a[position];
     },
-    write (uint8, position, value) {
-        uint8[position] = value;
+    write (uint8a, position, value) {
+        uint8a[position] = value;
         return value;
     }
 });
@@ -62,30 +62,30 @@ const Uint8 = new BytePrimitive({
 const HOSTLE_BE16 = {
     size: 2,
     // toBytes: Defined by instance.
-    read (uint8, position) {
-        this.bytes[1] = uint8[position + 0];
-        this.bytes[0] = uint8[position + 1];
+    read (uint8a, position) {
+        this.bytes[1] = uint8a[position + 0];
+        this.bytes[0] = uint8a[position + 1];
         return this.toBytes[0];
     },
-    write (uint8, position, value) {
+    write (uint8a, position, value) {
         this.toBytes[0] = value;
-        uint8[position + 0] = this.bytes[1];
-        uint8[position + 1] = this.bytes[0];
+        uint8a[position + 0] = this.bytes[1];
+        uint8a[position + 1] = this.bytes[0];
         return value;
     }
 };
 const HOSTBE_BE16 = {
     size: 2,
     // toBytes: Defined by instance.
-    read (uint8, position) {
-        this.bytes[0] = uint8[position + 0];
-        this.bytes[1] = uint8[position + 1];
+    read (uint8a, position) {
+        this.bytes[0] = uint8a[position + 0];
+        this.bytes[1] = uint8a[position + 1];
         return this.toBytes[0];
     },
-    write (uint8, position, value) {
+    write (uint8a, position, value) {
         this.toBytes[0] = value;
-        uint8[position + 0] = this.bytes[0];
-        uint8[position + 1] = this.bytes[1];
+        uint8a[position + 0] = this.bytes[0];
+        uint8a[position + 1] = this.bytes[1];
         return value;
     }
 };
@@ -108,38 +108,38 @@ const Int16BE = new BytePrimitive(Object.assign({}, BE16, {
 const HOSTLE_BE32 = {
     size: 4,
     // toBytes: Defined by instance.
-    read (uint8, position) {
-        this.bytes[3] = uint8[position + 0];
-        this.bytes[2] = uint8[position + 1];
-        this.bytes[1] = uint8[position + 2];
-        this.bytes[0] = uint8[position + 3];
+    read (uint8a, position) {
+        this.bytes[3] = uint8a[position + 0];
+        this.bytes[2] = uint8a[position + 1];
+        this.bytes[1] = uint8a[position + 2];
+        this.bytes[0] = uint8a[position + 3];
         return this.toBytes[0];
     },
-    write (uint8, position, value) {
+    write (uint8a, position, value) {
         this.toBytes[0] = value;
-        uint8[position + 0] = this.bytes[3];
-        uint8[position + 1] = this.bytes[2];
-        uint8[position + 2] = this.bytes[1];
-        uint8[position + 3] = this.bytes[0];
+        uint8a[position + 0] = this.bytes[3];
+        uint8a[position + 1] = this.bytes[2];
+        uint8a[position + 2] = this.bytes[1];
+        uint8a[position + 3] = this.bytes[0];
         return value;
     }
 };
 const HOSTBE_BE32 = {
     size: 4,
     // toBytes: Defined by instance.
-    read (uint8, position) {
-        this.bytes[0] = uint8[position + 0];
-        this.bytes[1] = uint8[position + 1];
-        this.bytes[2] = uint8[position + 2];
-        this.bytes[3] = uint8[position + 3];
+    read (uint8a, position) {
+        this.bytes[0] = uint8a[position + 0];
+        this.bytes[1] = uint8a[position + 1];
+        this.bytes[2] = uint8a[position + 2];
+        this.bytes[3] = uint8a[position + 3];
         return this.toBytes[0];
     },
-    write (uint8, position, value) {
+    write (uint8a, position, value) {
         this.toBytes[0] = value;
-        uint8[position + 0] = this.bytes[0];
-        uint8[position + 1] = this.bytes[1];
-        uint8[position + 2] = this.bytes[2];
-        uint8[position + 3] = this.bytes[3];
+        uint8a[position + 0] = this.bytes[0];
+        uint8a[position + 1] = this.bytes[1];
+        uint8a[position + 2] = this.bytes[2];
+        uint8a[position + 3] = this.bytes[3];
         return value;
     }
 };
@@ -183,30 +183,30 @@ const Uint32LE = new BytePrimitive(Object.assign({}, LE32, {
 
 const HOSTLE_BEDOUBLE = {
     size: 8,
-    read (uint8, position) {
-        this.bytes[7] = uint8[position + 0];
-        this.bytes[6] = uint8[position + 1];
-        this.bytes[5] = uint8[position + 2];
-        this.bytes[4] = uint8[position + 3];
-        this.bytes[3] = uint8[position + 4];
-        this.bytes[2] = uint8[position + 5];
-        this.bytes[1] = uint8[position + 6];
-        this.bytes[0] = uint8[position + 7];
+    read (uint8a, position) {
+        this.bytes[7] = uint8a[position + 0];
+        this.bytes[6] = uint8a[position + 1];
+        this.bytes[5] = uint8a[position + 2];
+        this.bytes[4] = uint8a[position + 3];
+        this.bytes[3] = uint8a[position + 4];
+        this.bytes[2] = uint8a[position + 5];
+        this.bytes[1] = uint8a[position + 6];
+        this.bytes[0] = uint8a[position + 7];
         return this.toBytes[0];
     }
 };
 
 const HOSTBE_BEDOUBLE = {
     size: 8,
-    read (uint8, position) {
-        this.bytes[7] = uint8[position + 0];
-        this.bytes[6] = uint8[position + 1];
-        this.bytes[5] = uint8[position + 2];
-        this.bytes[4] = uint8[position + 3];
-        this.bytes[3] = uint8[position + 4];
-        this.bytes[2] = uint8[position + 5];
-        this.bytes[1] = uint8[position + 6];
-        this.bytes[0] = uint8[position + 7];
+    read (uint8a, position) {
+        this.bytes[7] = uint8a[position + 0];
+        this.bytes[6] = uint8a[position + 1];
+        this.bytes[5] = uint8a[position + 2];
+        this.bytes[4] = uint8a[position + 3];
+        this.bytes[3] = uint8a[position + 4];
+        this.bytes[2] = uint8a[position + 5];
+        this.bytes[1] = uint8a[position + 6];
+        this.bytes[0] = uint8a[position + 7];
         return this.toBytes[0];
     }
 };
@@ -226,20 +226,20 @@ class FixedAsciiString extends BytePrimitive {
     constructor (size) {
         super({
             size,
-            read (uint8, position) {
+            read (uint8a, position) {
                 let str = '';
                 for (let i = 0; i < size; i++) {
-                    const code = uint8[position + i];
+                    const code = uint8a[position + i];
                     assert(code <= 127, 'Non-ascii character in FixedAsciiString');
                     str += String.fromCharCode(code);
                 }
                 return str;
             },
-            write (uint8, position, value) {
+            write (uint8a, position, value) {
                 for (let i = 0; i < size; i++) {
                     const code = value.charCodeAt(i);
                     assert(code <= 127, 'Non-ascii character in FixedAsciiString');
-                    uint8[position + i] = code;
+                    uint8a[position + i] = code;
                 }
                 return value;
             }

--- a/src/coders/byte-stream.js
+++ b/src/coders/byte-stream.js
@@ -5,13 +5,13 @@ class ByteStream {
         this.buffer = buffer;
         this.position = position;
 
-        this.uint8 = new Uint8Array(this.buffer);
+        this.uint8a = new Uint8Array(this.buffer);
     }
 
     read (member) {
-        const value = member.read(this.uint8, this.position);
+        const value = member.read(this.uint8a, this.position);
         if (member.size === 0) {
-            this.position += member.sizeOf(this.uint8, this.position);
+            this.position += member.sizeOf(this.uint8a, this.position);
         } else {
             this.position += member.size;
         }
@@ -19,19 +19,19 @@ class ByteStream {
     }
 
     readStruct (StructType) {
-        const obj = new StructType(this.uint8, this.position);
+        const obj = new StructType(this.uint8a, this.position);
         this.position += StructType.size;
         return obj;
     }
 
     resize (needed) {
         if (this.buffer.byteLength < needed) {
-            const uint8 = this.uint8;
+            const uint8a = this.uint8a;
             const nextPowerOf2 = Math.pow(2, Math.ceil(Math.log(needed) / Math.log(2)));
             this.buffer = new ArrayBuffer(nextPowerOf2);
 
-            this.uint8 = new Uint8Array(this.buffer);
-            this.uint8.set(uint8);
+            this.uint8a = new Uint8Array(this.buffer);
+            this.uint8a.set(uint8a);
         }
     }
 
@@ -42,9 +42,9 @@ class ByteStream {
             this.resize(this.position + member.size);
         }
 
-        member.write(this.uint8, this.position, value);
+        member.write(this.uint8a, this.position, value);
         if (member.size === 0) {
-            this.position += member.writeSizeOf(this.uint8, this.position);
+            this.position += member.writeSizeOf(this.uint8a, this.position);
         } else {
             this.position += member.size;
         }
@@ -54,7 +54,7 @@ class ByteStream {
     writeStruct (StructType, data) {
         this.resize(this.position + StructType.size);
 
-        const st = Object.assign(new StructType(this.uint8, this.position), data);
+        const st = Object.assign(new StructType(this.uint8a, this.position), data);
         this.position += StructType.size;
         return st;
     }
@@ -65,7 +65,7 @@ class ByteStream {
         this.resize(this.position + (end - start));
 
         for (let i = start; i < end; i++) {
-            this.uint8[this.position + i - start] = bytes[i];
+            this.uint8a[this.position + i - start] = bytes[i];
         }
         this.position += end - start;
         return bytes;

--- a/src/coders/crc32.js
+++ b/src/coders/crc32.js
@@ -1,0 +1,32 @@
+class CRC32 {
+    constructor () {
+        this.bit = new Uint32Array(1);
+        this.crc = 0;
+        this.c = 0;
+
+        this.table = [];
+        let c;
+        for (let i = 0; i < 256; i++) {
+            c = i;
+            for (let j = 0; j < 8; j++) {
+                c = (c & 1) ? (0xedb88320 ^ (c >>> 1)) : (c >>> 1);
+            }
+            this.table[i] = c >>> 0;
+        }
+    }
+
+    update (uint8a, position = 0, length = uint8a.length) {
+        let crc = (~this.crc) >>> 0;
+        for (let i = 0; i < length; i++) {
+            crc = (crc >>> 8) ^ this.table[(crc ^ uint8a[position + i]) & 0xff];
+        }
+        this.crc = (~crc) >>> 0;
+        return this;
+    }
+
+    get digest () {
+        return this.crc;
+    }
+}
+
+export {CRC32};

--- a/src/playground/field-object.js
+++ b/src/playground/field-object.js
@@ -1,0 +1,44 @@
+import {FieldObject} from '../squeak/field-object';
+
+import {ObjectRenderer} from './object';
+
+const allPropertyDescriptors = prototype => {
+    if (prototype === null) return {};
+    return Object.assign(
+        allPropertyDescriptors(Object.getPrototypeOf(prototype)),
+        Object.getOwnPropertyDescriptors(prototype)
+    );
+};
+
+class FieldObjectRenderer {
+    static check (data) {
+        return data instanceof FieldObject;
+    }
+
+    render (data, view) {
+        new ObjectRenderer().render(
+            Object.assign(() => (
+                Object.entries(
+                    allPropertyDescriptors(Object.getPrototypeOf(data))
+                )
+                    .filter(([, desc]) => desc.get)
+                    .reduce((carry, [key]) => {
+                        Object.defineProperty(carry, key, {
+                            enumerable: true,
+                            get () {
+                                return data[key];
+                            }
+                        });
+                        return carry;
+                    }, {})
+            ), {
+                toString () {
+                    return data.toString();
+                }
+            }),
+            view
+        );
+    }
+}
+
+export {FieldObjectRenderer};

--- a/src/playground/index.js
+++ b/src/playground/index.js
@@ -2,12 +2,14 @@ import {SB1File} from '../..';
 import {SB1View} from './view';
 
 import {ArrayRenderer} from './array';
+import {FieldObjectRenderer} from './field-object';
 import {FieldRenderer} from './field';
 import {JSPrimitiveRenderer} from './js-primitive';
 import {ObjectRenderer} from './object';
 import {ViewableRenderer} from './viewable';
 
 SB1View.register(ArrayRenderer);
+SB1View.register(FieldObjectRenderer);
 SB1View.register(FieldRenderer);
 SB1View.register(JSPrimitiveRenderer);
 SB1View.register(ObjectRenderer);
@@ -24,7 +26,13 @@ const readFile = f => {
         last = [
             new SB1View(sb1, 'file').element,
             new SB1View(Array.from(sb1.infoRaw()), 'raw - info').element,
-            new SB1View(Array.from(sb1.dataRaw()), 'raw - data').element
+            new SB1View(Array.from(sb1.dataRaw()), 'raw - data').element,
+            new SB1View(Array.from(sb1.infoTable()), 'table - info').element,
+            new SB1View(Array.from(sb1.dataTable()), 'table - data').element,
+            new SB1View(sb1.info(), 'info').element,
+            new SB1View(sb1.data(), 'data').element,
+            new SB1View(sb1.images(), 'images').element,
+            new SB1View(sb1.sounds(), 'sounds').element
         ];
         last.forEach(document.body.appendChild, document.body);
     };

--- a/src/squeak/byte-primitives.js
+++ b/src/squeak/byte-primitives.js
@@ -10,38 +10,38 @@ let ReferenceBE;
 if (IS_HOST_LITTLE_ENDIAN) {
     ReferenceBE = new BytePrimitive({
         size: 3,
-        read (uint8, position) {
+        read (uint8a, position) {
             return (
-                (uint8[position + 0] << 16) |
-                (uint8[position + 1] << 8) |
-                uint8[position + 2]
+                (uint8a[position + 0] << 16) |
+                (uint8a[position + 1] << 8) |
+                uint8a[position + 2]
             );
         }
     });
 } else {
     ReferenceBE = new BytePrimitive({
         size: 3,
-        read (uint8, position) {
+        read (uint8a, position) {
             return (
-                (uint8[position + 2] << 16) |
-                (uint8[position + 1] << 8) |
-                uint8[position + 0]
+                (uint8a[position + 2] << 16) |
+                (uint8a[position + 1] << 8) |
+                uint8a[position + 0]
             );
         }
     });
 }
 
 const LargeInt = new BytePrimitive({
-    sizeOf (uint8, position) {
-        const count = Int16BE.read(uint8, position);
+    sizeOf (uint8a, position) {
+        const count = Int16BE.read(uint8a, position);
         return Int16BE.size + count;
     },
-    read (uint8, position) {
+    read (uint8a, position) {
         let num = 0;
         let multiplier = 0;
-        const count = Int16BE.read(uint8, position);
+        const count = Int16BE.read(uint8a, position);
         for (let i = 0; i < count; i++) {
-            num = num + (multiplier * Uint8.read(uint8, position++));
+            num = num + (multiplier * Uint8.read(uint8a, position++));
             multiplier *= 256;
         }
         return num;
@@ -49,64 +49,64 @@ const LargeInt = new BytePrimitive({
 });
 
 const AsciiString = new BytePrimitive({
-    sizeOf (uint8, position) {
-        const count = Uint32BE.read(uint8, position);
+    sizeOf (uint8a, position) {
+        const count = Uint32BE.read(uint8a, position);
         return Uint32BE.size + count;
     },
-    read (uint8, position) {
-        const count = Uint32BE.read(uint8, position);
+    read (uint8a, position) {
+        const count = Uint32BE.read(uint8a, position);
         assert(count < BUFFER_TOO_BIG, 'asciiString too big');
         position += 4;
         let str = '';
         for (let i = 0; i < count; i++) {
-            str += String.fromCharCode(uint8[position++]);
+            str += String.fromCharCode(uint8a[position++]);
         }
         return str;
     }
 });
 
 const Bytes = new BytePrimitive({
-    sizeOf (uint8, position) {
-        return Uint32BE.size + Uint32BE.read(uint8, position);
+    sizeOf (uint8a, position) {
+        return Uint32BE.size + Uint32BE.read(uint8a, position);
     },
-    read (uint8, position) {
-        const count = Uint32BE.read(uint8, position);
+    read (uint8a, position) {
+        const count = Uint32BE.read(uint8a, position);
         assert(count < BUFFER_TOO_BIG, 'bytes too big');
         position += Uint32BE.size;
 
-        assert(count < BUFFER_TOO_BIG, 'uint8 array too big');
-        return new Uint8Array(uint8.buffer, position, count);
+        assert(count < BUFFER_TOO_BIG, 'uint8a array too big');
+        return new Uint8Array(uint8a.buffer, position, count);
     }
 });
 
 const SoundBytes = new BytePrimitive({
-    sizeOf (uint8, position) {
-        return Uint32BE.size + (Uint32BE.read(uint8, position) * 2);
+    sizeOf (uint8a, position) {
+        return Uint32BE.size + (Uint32BE.read(uint8a, position) * 2);
     },
-    read (uint8, position) {
-        const samples = Uint32BE.read(uint8, position);
+    read (uint8a, position) {
+        const samples = Uint32BE.read(uint8a, position);
         assert(samples < BUFFER_TOO_BIG, 'sound too big');
         position += Uint32BE.size;
 
         const count = samples * 2;
-        assert(count < BUFFER_TOO_BIG, 'uint8 array too big');
-        return new Uint8Array(uint8.buffer, position, count);
+        assert(count < BUFFER_TOO_BIG, 'uint8a array too big');
+        return new Uint8Array(uint8a.buffer, position, count);
     }
 });
 
 const Bitmap32BE = new BytePrimitive({
-    sizeOf (uint8, position) {
-        return Uint32BE.size + (Uint32BE.read(uint8, position) * Uint32BE.size);
+    sizeOf (uint8a, position) {
+        return Uint32BE.size + (Uint32BE.read(uint8a, position) * Uint32BE.size);
     },
-    read (uint8, position) {
-        const count = Uint32BE.read(uint8, position);
+    read (uint8a, position) {
+        const count = Uint32BE.read(uint8a, position);
         assert(count < BUFFER_TOO_BIG, 'bitmap too big');
         position += Uint32BE.size;
 
-        assert(count < BUFFER_TOO_BIG, 'uint8 array too big');
+        assert(count < BUFFER_TOO_BIG, 'uint8a array too big');
         const value = new Uint32Array(count);
         for (let i = 0; i < count; i++) {
-            value[i] = Uint32BE.read(uint8, position);
+            value[i] = Uint32BE.read(uint8a, position);
             position += Uint32BE.size;
         }
         return value;
@@ -122,23 +122,23 @@ if (typeof TextDecoder === 'undefined') {
 }
 
 const UTF8 = new BytePrimitive({
-    sizeOf (uint8, position) {
-        return Uint32BE.size + Uint32BE.read(uint8, position);
+    sizeOf (uint8a, position) {
+        return Uint32BE.size + Uint32BE.read(uint8a, position);
     },
-    read (uint8, position) {
-        const count = Uint32BE.read(uint8, position);
+    read (uint8a, position) {
+        const count = Uint32BE.read(uint8a, position);
         assert(count < BUFFER_TOO_BIG, 'utf8 too big');
         position += Uint32BE.size;
 
-        assert(count < BUFFER_TOO_BIG, 'uint8 array too big');
-        return decoder.decode(new Uint8Array(uint8.buffer, position, count));
+        assert(count < BUFFER_TOO_BIG, 'uint8a array too big');
+        return decoder.decode(new Uint8Array(uint8a.buffer, position, count));
     }
 });
 
 const OpaqueColor = new BytePrimitive({
     size: 4,
-    read (uint8, position) {
-        const rgb = Uint32BE.read(uint8, position);
+    read (uint8a, position) {
+        const rgb = Uint32BE.read(uint8a, position);
         const a = 0xff;
         const r = (rgb >> 22) & 0xff;
         const g = (rgb >> 12) & 0xff;
@@ -149,9 +149,9 @@ const OpaqueColor = new BytePrimitive({
 
 const TranslucentColor = new BytePrimitive({
     size: 5,
-    read (uint8, position) {
-        const rgb = Uint32BE.read(uint8, position);
-        const a = Uint8.read(uint8, position);
+    read (uint8a, position) {
+        const rgb = Uint32BE.read(uint8a, position);
+        const a = Uint8.read(uint8a, position);
         const r = (rgb >> 22) & 0xff;
         const g = (rgb >> 12) & 0xff;
         const b = (rgb >> 2) & 0xff;

--- a/src/squeak/field-iterator.js
+++ b/src/squeak/field-iterator.js
@@ -61,12 +61,13 @@ const CONSUMER_PROTOS = {
     [TYPES.OBJECT_REF]: {type: Reference, read: ReferenceBE}
 };
 
-const CONSUMERS = new Array(256).fill(null);
-for (const index of Object.values(TYPES)) {
-    if (CONSUMER_PROTOS[index]) {
-        CONSUMERS[index] = new Consumer(CONSUMER_PROTOS[index]);
+const CONSUMERS = Array.from(
+    {length: 256},
+    (_, i) => {
+        if (CONSUMER_PROTOS[i]) return new Consumer(CONSUMER_PROTOS[i]);
+        return null;
     }
-}
+);
 
 const builtinConsumer = new Consumer({
     type: BuiltinObjectHeader,
@@ -84,7 +85,7 @@ class FieldIterator {
     }
 
     next () {
-        if (this.stream.position >= this.stream.uint8.length) {
+        if (this.stream.position >= this.stream.uint8a.length) {
             return {
                 value: null,
                 done: true

--- a/src/squeak/field-object.js
+++ b/src/squeak/field-object.js
@@ -1,0 +1,61 @@
+import {TYPE_NAMES} from './ids';
+
+const toTitleCase = str => (
+    str.toLowerCase().replace(/_(\w)/g, ([, letter]) => letter.toUpperCase())
+);
+
+class FieldObject {
+    constructor ({classId, version, fields}) {
+        this.classId = classId;
+        this.version = version;
+        this.fields = fields;
+    }
+
+    string (field) {
+        return String(this.fields[field]);
+    }
+
+    number (field) {
+        return +this.fields[field];
+    }
+
+    boolean (field) {
+        return !!this.fields[field];
+    }
+
+    toString () {
+        if (this.constructor === FieldObject) {
+            return `${this.constructor.name} ${this.classId} ${TYPE_NAMES[this.classId]}`;
+        }
+        return this.constructor.name;
+    }
+
+    static define (FIELDS, Super = FieldObject) {
+        class Base extends Super {
+            get FIELDS () {
+                return FIELDS;
+            }
+
+            get RAW_FIELDS () {
+                return this.fields;
+            }
+
+            static get FIELDS () {
+                return FIELDS;
+            }
+        }
+
+        Object.keys(FIELDS).forEach(key => {
+            const index = FIELDS[key];
+            Object.defineProperty(Base.prototype, toTitleCase(key), {
+                get () {
+                    return this.fields[index];
+                }
+            });
+        });
+
+        return Base;
+    }
+}
+
+export {FieldObject};

--- a/src/squeak/reference-fixer.js
+++ b/src/squeak/reference-fixer.js
@@ -1,0 +1,39 @@
+import {Reference} from './fields';
+
+class ReferenceFixer {
+    constructor (table) {
+        this.table = Array.from(table);
+        this.fixed = this.fix(this.table);
+    }
+
+    fix () {
+        const fixed = [];
+
+        for (let i = 0; i < this.table.length; i++) {
+            this.fixItem(this.table[i]);
+            fixed.push(this.table[i]);
+        }
+
+        return fixed;
+    }
+
+    fixItem (item) {
+        if (typeof item.fields !== 'undefined') {
+            item = item.fields;
+        }
+        if (Array.isArray(item)) {
+            for (let i = 0; i < item.length; i++) {
+                item[i] = this.deref(item[i]);
+            }
+        }
+    }
+
+    deref (ref) {
+        if (ref instanceof Reference) {
+            return this.table[ref.index - 1];
+        }
+        return ref;
+    }
+}
+
+export {ReferenceFixer};

--- a/src/squeak/type-iterator.js
+++ b/src/squeak/type-iterator.js
@@ -1,0 +1,53 @@
+import {FieldObjectHeader, Header} from './fields';
+import {FieldObject} from './field-object';
+import {FIELD_OBJECT_CONTRUCTORS} from './types';
+
+class TypeIterator {
+    constructor (valueIterator) {
+        this.valueIterator = valueIterator;
+    }
+
+    [Symbol.iterator] () {
+        return this;
+    }
+
+    next () {
+        const nextHeader = this.valueIterator.next();
+        if (nextHeader.done) {
+            return nextHeader;
+        }
+
+        const header = nextHeader.value;
+        const {classId} = header;
+
+        let value = header;
+
+        if (header instanceof Header) {
+            value = [];
+
+            for (let i = 0; i < header.size; i++) {
+                value.push(this.next().value);
+            }
+        }
+
+        if (
+            FIELD_OBJECT_CONTRUCTORS[classId] !== null ||
+            header instanceof FieldObjectHeader
+        ) {
+            const constructor = FIELD_OBJECT_CONTRUCTORS[header.classId] || FieldObject;
+
+            value = new constructor({
+                classId: header.classId,
+                version: header.version,
+                fields: value
+            });
+        }
+
+        return {
+            value,
+            done: false
+        };
+    }
+}
+
+export {TypeIterator};

--- a/src/squeak/types.js
+++ b/src/squeak/types.js
@@ -1,0 +1,421 @@
+import {CRC32} from '../coders/crc32';
+
+import {FieldObject} from './field-object';
+import {value as valueOf} from './fields';
+import {TYPES} from './ids';
+
+class PointData extends FieldObject.define({
+    X: 0,
+    Y: 1
+}) {}
+
+export {PointData};
+
+class RectangleData extends FieldObject.define({
+    X: 0,
+    Y: 1,
+    X2: 2,
+    Y2: 3
+}) {
+    get width () {
+        return this.x2 - this.x;
+    }
+
+    get height () {
+        return this.y2 - this.y;
+    }
+}
+
+export {RectangleData};
+
+const _bgra2rgbaInPlace = uint8a => {
+    for (let i = 0; i < uint8a.length; i += 4) {
+        const r = uint8a[i + 2];
+        const b = uint8a[i + 0];
+        uint8a[i + 2] = b;
+        uint8a[i + 0] = r;
+    }
+    return uint8a;
+};
+
+class ImageData extends FieldObject.define({
+    WIDTH: 0,
+    HEIGHT: 1,
+    DEPTH: 2,
+    SOMETHING: 3,
+    BYTES: 4,
+    COLORMAP: 5
+}) {
+    get decoded () {
+        throw new Error('Not implemented');
+    }
+
+    get extension () {
+        return 'uncompressed';
+    }
+}
+
+export {ImageData};
+
+class StageData extends FieldObject.define({
+    STAGE_CONTENTS: 2,
+    OBJ_NAME: 6,
+    VARS: 7,
+    BLOCKS_BIN: 8,
+    IS_CLONE: 9,
+    MEDIA: 10,
+    CURRENT_COSTUME: 11,
+    ZOOM: 12,
+    H_PAN: 13,
+    V_PAN: 14,
+    OBSOLETE_SAVED_STATE: 15,
+    SPRITE_ORDER_IN_LIBRARY: 16,
+    VOLUME: 17,
+    TEMPO_BPM: 18,
+    SCENE_STATES: 19,
+    LISTS: 20
+}) {
+    get spriteOrderInLibrary () {
+        return this.fields[this.FIELDS.SPRITE_ORDER_IN_LIBRARY] || null;
+    }
+
+    get tempoBPM () {
+        return this.fields[this.FIELDS.TEMPO_BPM] || 0;
+    }
+
+    get lists () {
+        return this.fields[this.FIELDS.LISTS] || [];
+    }
+}
+
+export {StageData};
+
+class SpriteData extends FieldObject.define({
+    BOX: 0,
+    PARENT: 1,
+    COLOR: 3,
+    VISIBLE: 4,
+    OBJ_NAME: 6,
+    VARS: 7,
+    BLOCKS_BIN: 8,
+    IS_CLONE: 9,
+    MEDIA: 10,
+    CURRENT_COSTUME: 11,
+    VISIBILITY: 12,
+    SCALE_POINT: 13,
+    ROTATION_DEGREES: 14,
+    ROTATION_STYLE: 15,
+    VOLUME: 16,
+    TEMPO_BPM: 17,
+    DRAGGABLE: 18,
+    SCENE_STATES: 19,
+    LISTS: 20
+}) {
+    get scratchX () {
+        return this.box.x + this.currentCostume.rotationCenter.x - 240;
+    }
+
+    get scratchY () {
+        return 180 - (this.box.y + this.currentCostume.rotationCenter.y);
+    }
+
+    get visible () {
+        return (this.fields[this.FIELDS.VISIBLE] & 1) === 0;
+    }
+
+    get tempoBPM () {
+        return this.fields[this.FIELDS.TEMPO_BPM] || 0;
+    }
+
+    get lists () {
+        return this.fields[this.FIELDS.LISTS] || [];
+    }
+}
+
+export {SpriteData};
+
+class TextDetailsData extends FieldObject.define({
+    RECTANGLE: 0,
+    FONT: 8,
+    COLOR: 9,
+    LINES: 11
+}) {}
+
+export {TextDetailsData};
+
+class ImageMediaData extends FieldObject.define({
+    COSTUME_NAME: 0,
+    BITMAP: 1,
+    ROTATION_CENTER: 2,
+    TEXT_DETAILS: 3,
+    BASE_LAYER_DATA: 4,
+    OLD_COMPOSITE: 5
+}) {
+    get image () {
+        if (this.oldComposite instanceof ImageData) {
+            return this.oldComposite;
+        }
+        if (this.baseLayerData.value) {
+            return null;
+        }
+        return this.bitmap;
+    }
+
+    get width () {
+        if (this.image === null) {
+            return -1;
+        }
+        return this.image.width;
+    }
+
+    get height () {
+        if (this.image === null) {
+            return -1;
+        }
+        return this.image.height;
+    }
+
+    get rawBytes () {
+        if (this.image === null) {
+            return this.baseLayerData.value.slice();
+        }
+        return this.image.bytes.value;
+    }
+
+    get decoded () {
+        if (this.image === null) {
+            return this.baseLayerData.value.slice();
+        }
+        return this.image.decoded;
+    }
+
+    get crc () {
+        if (!this._crc) {
+            const crc = new CRC32()
+                .update(new Uint8Array(new Uint32Array([this.bitmap.width]).buffer))
+                .update(new Uint8Array(new Uint32Array([this.bitmap.height]).buffer))
+                .update(new Uint8Array(new Uint32Array([this.bitmap.depth]).buffer))
+                .update(this.rawBytes);
+            this._crc = crc.digest;
+        }
+        return this._crc;
+    }
+
+    get extension () {
+        if (this.oldComposite instanceof ImageData) return 'uncompressed';
+        if (this.baseLayerData.value) return 'jpg';
+        return 'uncompressed';
+    }
+
+    toString () {
+        return `ImageMediaData "${this.costumeName}"`;
+    }
+}
+
+export {ImageMediaData};
+
+class UncompressedData extends FieldObject.define({
+    DATA: 3,
+    RATE: 4
+}) {}
+
+export {UncompressedData};
+
+class SoundMediaData extends FieldObject.define({
+    NAME: 0,
+    UNCOMPRESSED: 1,
+    RATE: 4,
+    BITS_PER_SAMPLE: 5,
+    DATA: 6
+}) {
+    get rate () {
+        if (this.uncompressed.data.value.length !== 0) {
+            return this.uncompressed.rate;
+        }
+        return this.fields[this.FIELDS.RATE];
+    }
+
+    get rawBytes () {
+        if (this.data && this.data.value) {
+            return this.data.value;
+        }
+        return this.uncompressed.data.value;
+    }
+
+    get decoded () {
+        throw new Error('Not implemented');
+    }
+
+    get crc () {
+        if (!this._crc) {
+            this._crc = new CRC32()
+                .update(new Uint32Array([this.rate]))
+                .update(this.rawBytes)
+                .digest;
+        }
+        return this._crc;
+    }
+
+    get sampleCount () {
+        throw new Error('Not implemented');
+    }
+
+    get extension () {
+        return 'pcm';
+    }
+
+    toString () {
+        return `SoundMediaData "${this.name}"`;
+    }
+}
+
+export {SoundMediaData};
+
+class ListWatcherData extends FieldObject.define({
+    BOX: 0,
+    HIDDEN_WHEN_NULL: 1,
+    LIST_NAME: 8,
+    CONTENTS: 9,
+    TARGET: 10
+}) {
+    get x () {
+        if (valueOf(this.hiddenWhenNull) === null) return 5;
+        return this.box.x + 1;
+    }
+
+    get y () {
+        if (valueOf(this.hiddenWhenNull) === null) return 5;
+        return this.box.y + 1;
+    }
+
+    get width () {
+        return this.box.width - 2;
+    }
+
+    get height () {
+        return this.box.height - 2;
+    }
+}
+
+export {ListWatcherData};
+
+class AlignmentData extends FieldObject.define({
+    BOX: 0,
+    PARENT: 1,
+    FRAMES: 2,
+    COLOR: 3,
+    DIRECTION: 8,
+    ALIGNMENT: 9
+}) {}
+
+export {AlignmentData};
+
+class MorphData extends FieldObject.define({
+    BOX: 0,
+    PARENT: 1,
+    COLOR: 3
+}) {}
+
+export {MorphData};
+
+class StaticStringData extends FieldObject.define({
+    BOX: 0,
+    COLOR: 3,
+    VALUE: 8
+}) {}
+
+export {StaticStringData};
+
+class UpdatingStringData extends FieldObject.define({
+    BOX: 0,
+    READOUT_FRAME: 1,
+    COLOR: 3,
+    FONT: 6,
+    VALUE: 8,
+    TARGET: 10,
+    CMD: 11,
+    PARAM: 13
+}) {}
+
+export {UpdatingStringData};
+
+class WatcherReadoutFrameData extends FieldObject.define({
+    BOX: 0
+}) {}
+
+export {WatcherReadoutFrameData};
+
+const WATCHER_MODES = {
+    NORMAL: 1,
+    LARGE: 2,
+    SLIDER: 3,
+    TEXT: 4
+};
+
+export {WATCHER_MODES};
+
+class WatcherData extends FieldObject.define({
+    BOX: 0,
+    TARGET: 1,
+    SHAPE: 2,
+    READOUT: 14,
+    READOUT_FRAME: 15,
+    SLIDER: 16,
+    ALIGNMENT: 17,
+    SLIDER_MIN: 20,
+    SLIDER_MAX: 21
+}) {
+    get x () {
+        return this.box.x;
+    }
+
+    get y () {
+        return this.box.y;
+    }
+
+    get mode () {
+        if (valueOf(this.slider) === null) {
+            if (this.readoutFrame.box.height <= 14) {
+                return WATCHER_MODES.NORMAL;
+            }
+            return WATCHER_MODES.LARGE;
+        }
+        return WATCHER_MODES.SLIDER;
+    }
+
+    get isDiscrete () {
+        return (
+            Math.floor(this.sliderMin) === this.sliderMin &&
+            Math.floor(this.sliderMax) === this.sliderMax &&
+            Math.floor(this.readout.value) === this.readout.value
+        );
+    }
+}
+
+export {WatcherData};
+
+const FIELD_OBJECT_CONTRUCTOR_PROTOS = {
+    [TYPES.POINT]: PointData,
+    [TYPES.RECTANGLE]: RectangleData,
+    [TYPES.FORM]: ImageData,
+    [TYPES.SQUEAK]: ImageData,
+    [TYPES.SAMPLED_SOUND]: UncompressedData,
+    [TYPES.SPRITE]: SpriteData,
+    [TYPES.STAGE]: StageData,
+    [TYPES.IMAGE_MEDIA]: ImageMediaData,
+    [TYPES.SOUND_MEDIA]: SoundMediaData,
+    [TYPES.ALIGNMENT]: AlignmentData,
+    [TYPES.MORPH]: MorphData,
+    [TYPES.WATCHER_READOUT_FRAME]: WatcherReadoutFrameData,
+    [TYPES.STATIC_STRING]: StaticStringData,
+    [TYPES.UPDATING_STRING]: UpdatingStringData,
+    [TYPES.WATCHER]: WatcherData,
+    [TYPES.LIST_WATCHER]: ListWatcherData
+};
+
+const FIELD_OBJECT_CONTRUCTORS = Array.from(
+    {length: 256},
+    (_, i) => (FIELD_OBJECT_CONTRUCTOR_PROTOS[i] || null)
+);
+
+export {FIELD_OBJECT_CONTRUCTORS};


### PR DESCRIPTION
Live playground: https://mzgoddard.github.io/scratch-sb1-converter/squeak-types/

- Add FieldObject, a collection of Fields from an `.sb` file
- Add FieldObject subclasses that provide mappings from the `fields` array to helpful names
- Collect Fields into FieldObject subclass instances with TypeIterator
- Replace References with the referenced FieldObject or Value from the object table created and fixed by ReferenceFixer

### FieldObject

A FieldObject instance is passed an array of collected fields. FieldObject subclasses provide a mapping of key names to field indices that are turned into getter properties to easily derefence those values.

Here is an example FieldObject subclass:

```js
class RectangleData extends FieldObject.define({
    X: 0,
    Y: 1,
    X2: 2,
    Y2: 3
}) {
    get width () {
        return this.x2 - this.x;
    }
     get height () {
        return this.y2 - this.y;
    }
}
```

### TODO

- [x] Publish live playground url
<del>- [ ] Documentation!</del>
<del>- [ ] Tests!</del>
Documentation and tests will be in a follow up PR.
