### PR TITLE
Convert squeak bitmaps and audio samples to uncompressed png and wav files

### DIFF
--- a/src/coders/adler32.js
+++ b/src/coders/adler32.js
@@ -1,0 +1,22 @@
+class Adler32 {
+    constructor () {
+        this.adler = 1;
+    }
+
+    update (uint8a, position, length) {
+        let a = this.adler & 0xffff;
+        let b = this.adler >>> 16;
+        for (let i = 0; i < length; i++) {
+            a = (a + uint8a[position + i]) % 65521;
+            b = (b + a) % 65521;
+        }
+        this.adler = (b << 16) | a;
+        return this;
+    }
+
+    get digest () {
+        return this.adler;
+    }
+}
+
+export {Adler32};

--- a/src/coders/deflate-packets.js
+++ b/src/coders/deflate-packets.js
@@ -1,0 +1,33 @@
+import {Packet} from './byte-packets';
+import {Uint8, Uint16LE, Uint32LE} from './byte-primitives';
+
+const DEFLATE_BLOCK_SIZE_MAX = 0xffff;
+
+export {DEFLATE_BLOCK_SIZE_MAX};
+
+class DeflateHeader extends Packet.extend({
+    cmf: Uint8,
+    flag: Uint8
+}) {}
+
+Packet.initConstructor(DeflateHeader);
+
+export {DeflateHeader};
+
+class DeflateChunkStart extends Packet.extend({
+    lastPacket: Uint8,
+    length: Uint16LE,
+    lengthCheck: Uint16LE
+}) {}
+
+Packet.initConstructor(DeflateChunkStart);
+
+export {DeflateChunkStart};
+
+class DeflateEnd extends Packet.extend({
+    checksum: Uint32LE
+}) {}
+
+Packet.initConstructor(DeflateEnd);
+
+export {DeflateEnd};

--- a/src/coders/deflate-stream.js
+++ b/src/coders/deflate-stream.js
@@ -1,0 +1,79 @@
+import {Adler32} from './adler32';
+import {DEFLATE_BLOCK_SIZE_MAX, DeflateHeader, DeflateChunkStart, DeflateEnd} from './deflate-packets';
+import {ProxyStream} from './proxy-stream';
+
+class DeflateStream extends ProxyStream {
+    constructor (stream) {
+        super(stream);
+
+        this.stream.writeStruct(DeflateHeader, {
+            cmf: 0b00001000,
+            flag: 0b00011101
+        });
+
+        this.adler = new Adler32();
+
+        this.chunk = this.stream.writeStruct(DeflateChunkStart, {
+            lastPacket: 0,
+            length: 0,
+            lengthCheck: 0 ^ 0xffff
+        });
+    }
+
+    get _deflateIndex () {
+        return this.chunk.length;
+    }
+
+    set _deflateIndex (value) {
+        this.chunk.length = value;
+        this.chunk.lengthCheck = value ^ 0xffff;
+        return this.chunk.length;
+    }
+
+    writeStruct (StructType, data) {
+        this.writeBytes(Object.assign(new StructType(), data).uint8a);
+    }
+
+    writeBytes (bytes, start = 0, end = bytes.length) {
+        let chunkStart = start;
+        while (end - chunkStart > 0) {
+            if (this._deflateIndex === DEFLATE_BLOCK_SIZE_MAX) {
+                this.chunk = this.stream.writeStruct(DeflateChunkStart, {
+                    lastPacket: 0,
+                    length: 0,
+                    lengthCheck: 0 ^ 0xffff
+                });
+            }
+
+            const chunkLength = Math.min(
+                end - chunkStart,
+                DEFLATE_BLOCK_SIZE_MAX - this._deflateIndex
+            );
+            this.stream.writeBytes(bytes, chunkStart, chunkStart + chunkLength);
+            this._deflateIndex += chunkLength;
+            chunkStart += chunkLength;
+        }
+
+        this.adler.update(bytes, start, end - start);
+    }
+
+    finish () {
+        this.chunk.lastPacket = 1;
+
+        this.stream.writeStruct(DeflateEnd, {
+            checksum: this.adler.digest
+        });
+    }
+
+    static estimateSize (bodySize) {
+        const packets = Math.ceil(bodySize / DEFLATE_BLOCK_SIZE_MAX);
+        return (
+            DeflateHeader.size +
+            (packets * DeflateChunkStart.size) +
+            DeflateEnd.size +
+            bodySize
+        );
+    }
+}
+
+export {DeflateStream};

--- a/src/coders/png-chunk-stream.js
+++ b/src/coders/png-chunk-stream.js
@@ -1,0 +1,34 @@
+import {Uint32BE} from './byte-primitives';
+import {CRC32} from './crc32';
+import {PNGChunkStart, PNGChunkEnd} from './png-packets';
+import {ProxyStream} from './proxy-stream';
+
+class PNGChunkStream extends ProxyStream {
+    constructor (stream, chunkType = 'IHDR') {
+        super(stream);
+
+        this.start = this.stream.writeStruct(PNGChunkStart, {
+            length: 0,
+            chunkType
+        });
+
+        this.crc = new CRC32();
+    }
+
+    finish () {
+        const crcStart = this.start.offset + this.start.size;
+        const length = this.position - crcStart;
+        this.start.length = length;
+
+        this.crc.update(this.stream.uint8a, crcStart - Uint32BE.size, length + Uint32BE.size);
+        this.stream.writeStruct(PNGChunkEnd, {
+            checksum: this.crc.digest
+        });
+    }
+
+    static size (bodySize) {
+        return PNGChunkStart.size + bodySize + PNGChunkEnd.size;
+    }
+}
+
+export {PNGChunkStream};

--- a/src/coders/png-file.js
+++ b/src/coders/png-file.js
@@ -1,0 +1,81 @@
+import {ByteStream} from './byte-stream';
+import {PNGSignature, PNGIHDRChunkBody, PNGFilterMethodByte} from './png-packets';
+import {DeflateStream} from './deflate-stream';
+import {PNGChunkStream} from './png-chunk-stream';
+
+class PNGFile {
+    encode (width, height, pixelsUint8) {
+        const rowSize = (width * 4) + PNGFilterMethodByte.size;
+        const bodySize = rowSize * height;
+        const size = (
+            PNGSignature.size +
+            // IHDR
+            PNGChunkStream.size(PNGIHDRChunkBody.size) +
+            // IDAT
+            PNGChunkStream.size(DeflateStream.estimateSize(bodySize)) +
+            // IEND
+            PNGChunkStream.size(0)
+        );
+
+        const stream = new ByteStream(new ArrayBuffer(size));
+
+        stream.writeStruct(PNGSignature, {
+            support8Bit: 0x89,
+            png: 'PNG',
+            dosLineEnding: '\r\n',
+            dosEndOfFile: '\x1a',
+            unixLineEnding: '\n'
+        });
+
+        const pngIhdr = new PNGChunkStream(stream, 'IHDR');
+
+        pngIhdr.writeStruct(PNGIHDRChunkBody, {
+            width,
+            height,
+            bitDepth: 8,
+            colorType: 6,
+            compressionMethod: 0,
+            filterMethod: 0,
+            interlaceMethod: 0
+        });
+
+        pngIhdr.finish();
+
+        const pngIdat = new PNGChunkStream(stream, 'IDAT');
+
+        const deflate = new DeflateStream(pngIdat);
+
+        let pixelsIndex = 0;
+        while (pixelsIndex < pixelsUint8.length) {
+            deflate.writeStruct(PNGFilterMethodByte, {
+                method: 0
+            });
+
+            const partialLength = Math.min(
+                pixelsUint8.length - pixelsIndex,
+                rowSize - PNGFilterMethodByte.size
+            );
+            deflate.writeBytes(
+                pixelsUint8, pixelsIndex, pixelsIndex + partialLength
+            );
+
+            pixelsIndex += partialLength;
+        }
+
+        deflate.finish();
+
+        pngIdat.finish();
+
+        const pngIend = new PNGChunkStream(stream, 'IEND');
+
+        pngIend.finish();
+
+        return stream.buffer;
+    }
+
+    static encode (width, height, pixels) {
+        return new PNGFile().encode(width, height, pixels);
+    }
+}
+
+export {PNGFile};

--- a/src/coders/png-packets.js
+++ b/src/coders/png-packets.js
@@ -1,0 +1,65 @@
+import {assert} from '../util/assert';
+
+import {Packet} from './byte-packets';
+import {Uint8, Uint32BE, FixedAsciiString} from './byte-primitives';
+
+class PNGSignature extends Packet.extend({
+    support8Bit: Uint8,
+    png: new FixedAsciiString(3),
+    dosLineEnding: new FixedAsciiString(2),
+    dosEndOfFile: new FixedAsciiString(1),
+    unixLineEnding: new FixedAsciiString(1)
+}) {
+    static validate () {
+        assert(this.equals({
+            support8Bit: 0x89,
+            png: 'PNG',
+            dosLineEnding: '\r\n',
+            dosEndOfFile: '\x1a',
+            unixLineEnding: '\n'
+        }), 'PNGSignature does not match the expected values');
+    }
+}
+
+Packet.initConstructor(PNGSignature);
+
+export {PNGSignature};
+
+class PNGChunkStart extends Packet.extend({
+    length: Uint32BE,
+    chunkType: new FixedAsciiString(4)
+}) {}
+
+Packet.initConstructor(PNGChunkStart);
+
+export {PNGChunkStart};
+
+class PNGChunkEnd extends Packet.extend({
+    checksum: Uint32BE
+}) {}
+
+Packet.initConstructor(PNGChunkEnd);
+
+export {PNGChunkEnd};
+
+class PNGIHDRChunkBody extends Packet.extend({
+    width: Uint32BE,
+    height: Uint32BE,
+    bitDepth: Uint8,
+    colorType: Uint8,
+    compressionMethod: Uint8,
+    filterMethod: Uint8,
+    interlaceMethod: Uint8
+}) {}
+
+Packet.initConstructor(PNGIHDRChunkBody);
+
+export {PNGIHDRChunkBody};
+
+class PNGFilterMethodByte extends Packet.extend({
+    method: Uint8
+}) {}
+
+Packet.initConstructor(PNGFilterMethodByte);
+
+export {PNGFilterMethodByte};

--- a/src/coders/proxy-stream.js
+++ b/src/coders/proxy-stream.js
@@ -1,0 +1,33 @@
+class ProxyStream {
+    constructor (stream) {
+        this.stream = stream;
+    }
+
+    get uint8a () {
+        return this.stream.uint8a;
+    }
+
+    set uint8a (value) {
+        this.stream.uint8a = value;
+        return this.stream.uint8a;
+    }
+
+    get position () {
+        return this.stream.position;
+    }
+
+    set position (value) {
+        this.stream.position = value;
+        return this.stream.position;
+    }
+
+    writeStruct (StructType, data) {
+        return this.stream.writeStruct(StructType, data);
+    }
+
+    writeBytes (bytes, start = 0, end = bytes.length) {
+        return this.stream.writeBytes(bytes, start, end);
+    }
+}
+
+export {ProxyStream};

--- a/src/coders/squeak-image.js
+++ b/src/coders/squeak-image.js
@@ -1,0 +1,200 @@
+import {BytePrimitive, Uint8, Uint32BE} from './byte-primitives';
+import {ByteStream} from './byte-stream';
+
+const defaultColorMap = [
+    0x00000000, 0xFF000000, 0xFFFFFFFF, 0xFF808080, 0xFFFF0000, 0xFF00FF00, 0xFF0000FF, 0xFF00FFFF,
+    0xFFFFFF00, 0xFFFF00FF, 0xFF202020, 0xFF404040, 0xFF606060, 0xFF9F9F9F, 0xFFBFBFBF, 0xFFDFDFDF,
+    0xFF080808, 0xFF101010, 0xFF181818, 0xFF282828, 0xFF303030, 0xFF383838, 0xFF484848, 0xFF505050,
+    0xFF585858, 0xFF686868, 0xFF707070, 0xFF787878, 0xFF878787, 0xFF8F8F8F, 0xFF979797, 0xFFA7A7A7,
+    0xFFAFAFAF, 0xFFB7B7B7, 0xFFC7C7C7, 0xFFCFCFCF, 0xFFD7D7D7, 0xFFE7E7E7, 0xFFEFEFEF, 0xFFF7F7F7,
+    0xFF000000, 0xFF003300, 0xFF006600, 0xFF009900, 0xFF00CC00, 0xFF00FF00, 0xFF000033, 0xFF003333,
+    0xFF006633, 0xFF009933, 0xFF00CC33, 0xFF00FF33, 0xFF000066, 0xFF003366, 0xFF006666, 0xFF009966,
+    0xFF00CC66, 0xFF00FF66, 0xFF000099, 0xFF003399, 0xFF006699, 0xFF009999, 0xFF00CC99, 0xFF00FF99,
+    0xFF0000CC, 0xFF0033CC, 0xFF0066CC, 0xFF0099CC, 0xFF00CCCC, 0xFF00FFCC, 0xFF0000FF, 0xFF0033FF,
+    0xFF0066FF, 0xFF0099FF, 0xFF00CCFF, 0xFF00FFFF, 0xFF330000, 0xFF333300, 0xFF336600, 0xFF339900,
+    0xFF33CC00, 0xFF33FF00, 0xFF330033, 0xFF333333, 0xFF336633, 0xFF339933, 0xFF33CC33, 0xFF33FF33,
+    0xFF330066, 0xFF333366, 0xFF336666, 0xFF339966, 0xFF33CC66, 0xFF33FF66, 0xFF330099, 0xFF333399,
+    0xFF336699, 0xFF339999, 0xFF33CC99, 0xFF33FF99, 0xFF3300CC, 0xFF3333CC, 0xFF3366CC, 0xFF3399CC,
+    0xFF33CCCC, 0xFF33FFCC, 0xFF3300FF, 0xFF3333FF, 0xFF3366FF, 0xFF3399FF, 0xFF33CCFF, 0xFF33FFFF,
+    0xFF660000, 0xFF663300, 0xFF666600, 0xFF669900, 0xFF66CC00, 0xFF66FF00, 0xFF660033, 0xFF663333,
+    0xFF666633, 0xFF669933, 0xFF66CC33, 0xFF66FF33, 0xFF660066, 0xFF663366, 0xFF666666, 0xFF669966,
+    0xFF66CC66, 0xFF66FF66, 0xFF660099, 0xFF663399, 0xFF666699, 0xFF669999, 0xFF66CC99, 0xFF66FF99,
+    0xFF6600CC, 0xFF6633CC, 0xFF6666CC, 0xFF6699CC, 0xFF66CCCC, 0xFF66FFCC, 0xFF6600FF, 0xFF6633FF,
+    0xFF6666FF, 0xFF6699FF, 0xFF66CCFF, 0xFF66FFFF, 0xFF990000, 0xFF993300, 0xFF996600, 0xFF999900,
+    0xFF99CC00, 0xFF99FF00, 0xFF990033, 0xFF993333, 0xFF996633, 0xFF999933, 0xFF99CC33, 0xFF99FF33,
+    0xFF990066, 0xFF993366, 0xFF996666, 0xFF999966, 0xFF99CC66, 0xFF99FF66, 0xFF990099, 0xFF993399,
+    0xFF996699, 0xFF999999, 0xFF99CC99, 0xFF99FF99, 0xFF9900CC, 0xFF9933CC, 0xFF9966CC, 0xFF9999CC,
+    0xFF99CCCC, 0xFF99FFCC, 0xFF9900FF, 0xFF9933FF, 0xFF9966FF, 0xFF9999FF, 0xFF99CCFF, 0xFF99FFFF,
+    0xFFCC0000, 0xFFCC3300, 0xFFCC6600, 0xFFCC9900, 0xFFCCCC00, 0xFFCCFF00, 0xFFCC0033, 0xFFCC3333,
+    0xFFCC6633, 0xFFCC9933, 0xFFCCCC33, 0xFFCCFF33, 0xFFCC0066, 0xFFCC3366, 0xFFCC6666, 0xFFCC9966,
+    0xFFCCCC66, 0xFFCCFF66, 0xFFCC0099, 0xFFCC3399, 0xFFCC6699, 0xFFCC9999, 0xFFCCCC99, 0xFFCCFF99,
+    0xFFCC00CC, 0xFFCC33CC, 0xFFCC66CC, 0xFFCC99CC, 0xFFCCCCCC, 0xFFCCFFCC, 0xFFCC00FF, 0xFFCC33FF,
+    0xFFCC66FF, 0xFFCC99FF, 0xFFCCCCFF, 0xFFCCFFFF, 0xFFFF0000, 0xFFFF3300, 0xFFFF6600, 0xFFFF9900,
+    0xFFFFCC00, 0xFFFFFF00, 0xFFFF0033, 0xFFFF3333, 0xFFFF6633, 0xFFFF9933, 0xFFFFCC33, 0xFFFFFF33,
+    0xFFFF0066, 0xFFFF3366, 0xFFFF6666, 0xFFFF9966, 0xFFFFCC66, 0xFFFFFF66, 0xFFFF0099, 0xFFFF3399,
+    0xFFFF6699, 0xFFFF9999, 0xFFFFCC99, 0xFFFFFF99, 0xFFFF00CC, 0xFFFF33CC, 0xFFFF66CC, 0xFFFF99CC,
+    0xFFFFCCCC, 0xFFFFFFCC, 0xFFFF00FF, 0xFFFF33FF, 0xFFFF66FF, 0xFFFF99FF, 0xFFFFCCFF, 0xFFFFFFFF];
+
+const defaultOneBitColorMap = [0xFFFFFFFF, 0xFF000000];
+
+const VariableIntBE = new BytePrimitive({
+    sizeOf (uint8a, position) {
+        const count = uint8a[position];
+        if (count <= 223) return 1;
+        if (count <= 254) return 2;
+        return 5;
+    },
+    read (uint8a, position) {
+        const count = uint8a[position];
+        if (count <= 223) return count;
+        if (count <= 254) return ((count - 224) * 256) + uint8a[position + 1];
+        return Uint32BE.read(uint8a, position + 1);
+    }
+});
+
+class SqueakImage {
+    decode (width, height, depth, bytes, colormap) {
+        const pixels = this.decodePixels(bytes, depth === 32);
+
+        if (depth <= 8) {
+            if (!colormap) {
+                colormap = depth === 1 ? defaultOneBitColorMap : defaultColorMap;
+            }
+            return this.unpackPixels(pixels, width, height, depth, colormap);
+        } else if (depth === 16) {
+            return this.raster16To32(pixels, width, height);
+        } else if (depth === 32) {
+            return pixels;
+        }
+        throw new Error('Unhandled Squeak Image depth.');
+    }
+
+    decodePixels (bytes, withAlpha) {
+        let result;
+
+        // Already decompressed
+        if (Array.isArray(bytes) || bytes instanceof Uint32Array) {
+            result = new Uint32Array(bytes);
+            if (withAlpha) {
+                for (let i = 0; i < result.length; i++) {
+                    if (result[i] !== 0) {
+                        result[i] = 0xff000000 | result[i];
+                    }
+                }
+            }
+            return result;
+        }
+
+        const stream = new ByteStream(bytes.buffer, bytes.byteOffset);
+
+        const pixelsOut = stream.read(VariableIntBE);
+        result = new Uint32Array(pixelsOut);
+
+        let i = 0;
+        while (i < pixelsOut) {
+            const runLengthAndCode = stream.read(VariableIntBE);
+            const runLength = runLengthAndCode >> 2;
+            const code = runLengthAndCode & 0b11;
+
+            let w;
+
+            switch (code) {
+            case 0:
+                i += runLength;
+                break;
+
+            case 1:
+                w = stream.read(Uint8);
+                w = (w << 24) | (w << 16) | (w << 8) | w;
+                if (withAlpha && w !== 0) {
+                    w |= 0xff000000;
+                }
+                for (let j = 0; j < runLength; j++) {
+                    result[i++] = w;
+                }
+                break;
+
+            case 2:
+                w = stream.read(Uint32BE);
+                if (withAlpha && w !== 0) {
+                    w |= 0xff000000;
+                }
+                for (let j = 0; j < runLength; j++) {
+                    result[i++] = w;
+                }
+                break;
+
+            case 3:
+                for (let j = 0; j < runLength; j++) {
+                    w = stream.read(Uint32BE);
+                    if (withAlpha && w !== 0) {
+                        w |= 0xff000000;
+                    }
+                    result[i++] = w;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    unpackPixels (words, width, height, depth, colormap) {
+        const result = new Uint32Array(width * height);
+        const mask = (1 << depth) - 1;
+        const pixelsPerWord = 32 / depth;
+        let dst = 0;
+
+        let src = 0;
+        for (let y = 0; y < height; y++) {
+            let word;
+            let shift = -1;
+            for (let x = 0; x < width; x++) {
+                if (shift < 0) {
+                    shift = depth * (pixelsPerWord - 1);
+                    word = words[src++];
+                }
+                result[dst++] = colormap[(word >> shift) & mask];
+                shift -= depth;
+            }
+        }
+        return result;
+    }
+
+    raster16To32 (words, width, height) {
+        const result = new Uint32Array(2 * words.length);
+        let shift;
+        let word;
+        let pix;
+        let src = 0;
+        let dst = 0;
+        for (let y = 0; y < height; y++) {
+            shift = -1;
+            for (let x = 0; x < width; x++) {
+                if (shift < 0) {
+                    shift = 16;
+                    word = words[src++];
+                }
+                pix = (word >> shift) & 0xffff;
+                if (pix !== 0) {
+                    const red = (pix >> 7) & 0b11111000;
+                    const green = (pix >> 2) & 0b11111000;
+                    const blue = (pix << 3) & 0b11111000;
+                    pix = 0xff000000 | (red << 16) | (green << 8) | blue;
+                }
+                result[dst++] = pix;
+                shift -= 16;
+            }
+        }
+        return result;
+    }
+
+    buildCustomColormap (depth, colors, table) {
+        const result = new Uint32Array(1 << depth);
+        for (let i = 0; i < colors.length; i++) {
+            result[i] = table[colors[i].index - 1];
+        }
+        return result;
+    }
+}
+
+export {SqueakImage};

--- a/src/coders/squeak-sound.js
+++ b/src/coders/squeak-sound.js
@@ -1,0 +1,114 @@
+import {assert} from '../util/assert';
+
+import {Uint8} from './byte-primitives';
+import {ByteStream} from './byte-stream';
+
+const SQUEAK_SOUND_STEP_SIZE_TABLE = [
+    7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 19, 21, 23, 25, 28, 31, 34, 37, 41,
+    45, 50, 55, 60, 66, 73, 80, 88, 97, 107, 118, 130, 143, 157, 173, 190, 209,
+    230, 253, 279, 307, 337, 371, 408, 449, 494, 544, 598, 658, 724, 796, 876,
+    963, 1060, 1166, 1282, 1411, 1552, 1707, 1878, 2066, 2272, 2499, 2749,
+    3024, 3327, 3660, 4026, 4428, 4871, 5358, 5894, 6484, 7132, 7845, 8630,
+    9493, 10442, 11487, 12635, 13899, 15289, 16818, 18500, 20350, 22385, 24623,
+    27086, 29794, 32767
+];
+
+const SQUEAK_SOUND_INDEX_TABLES = {
+    2: [-1, 2, -1, 2],
+    3: [-1, -1, 2, 4, -1, -1, 2, 4],
+    4: [-1, -1, -1, -1, 2, 4, 6, 8, -1, -1, -1, -1, 2, 4, 6, 8],
+    5: [
+        -1, -1, -1, -1, -1, -1, -1, -1, 1, 2, 4, 6, 8, 10, 13, 16,
+        -1, -1, -1, -1, -1, -1, -1, -1, 1, 2, 4, 6, 8, 10, 13, 16
+    ]
+};
+
+class SqueakSound {
+    constructor (bitsPerSample) {
+        this.bitsPerSample = bitsPerSample;
+
+        this.indexTable = SQUEAK_SOUND_INDEX_TABLES[bitsPerSample];
+
+        this.signMask = 1 << (bitsPerSample - 1);
+        this.valueMask = this.signMask - 1;
+        this.valueHighBit = this.signMask >> 1;
+
+        this.bitPosition = 0;
+        this.currentByte = 0;
+
+        this.stream = null;
+        this.end = 0;
+    }
+
+    decode (data) {
+        // Reset position information.
+        this.bitPosition = 0;
+        this.currentByte = 0;
+
+        this.stream = new ByteStream(data.buffer, data.byteOffset);
+        this.end = data.byteOffset + data.length;
+
+        const size = Math.floor(data.length * 8 / this.bitsPerSample);
+        const result = new Int16Array(size);
+
+        let sample = 0;
+        let index = 0;
+
+        for (let i = 0; i < size; i++) {
+            const code = this.nextCode();
+
+            assert(code >= 0, 'Ran out of bits in Squeak Sound');
+
+            let step = SQUEAK_SOUND_STEP_SIZE_TABLE[index];
+            let delta = 0;
+            for (let bit = this.valueHighBit; bit > 0; bit = bit >> 1) {
+                if ((code & bit) !== 0) {
+                    delta += step;
+                }
+                step = step >> 1;
+            }
+            delta += step;
+
+            sample += ((code & this.signMask) === 0) ? delta : -delta;
+
+            index += this.indexTable[code];
+            if (index < 0) index = 0;
+            if (index > 88) index = 88;
+
+            if (sample > 32767) sample = 32767;
+            if (sample < -32768) sample = -32768;
+
+            result[i] = sample;
+        }
+
+        return result;
+    }
+
+    nextCode () {
+        let remaining = this.bitsPerSample;
+        let shift = remaining - this.bitPosition;
+        let result = (shift < 0) ? (this.currentByte >> -shift) : (this.currentByte << shift);
+        while (shift > 0) {
+            remaining -= this.bitPosition;
+            if (this.end - this.stream.position > 0) {
+                this.currentByte = this.stream.read(Uint8);
+                this.bitPosition = 8;
+            } else {
+                this.currentByte = 0;
+                this.bitPosition = 0;
+                return -1;
+            }
+            shift = remaining - this.bitPosition;
+            result += (shift < 0) ? (this.currentByte >> -shift) : (this.currentByte << shift);
+        }
+        this.bitPosition -= remaining;
+        this.currentByte = this.currentByte & (0xff >> (8 - this.bitPosition));
+        return result;
+    }
+
+    static samples (bitsPerSample, data) {
+        return data.length * 8 / bitsPerSample;
+    }
+}
+
+export {SqueakSound};

--- a/src/coders/wav-file.js
+++ b/src/coders/wav-file.js
@@ -1,0 +1,58 @@
+import {ByteStream} from './byte-stream';
+import {WAVESignature, WAVEChunkStart, WAVEFMTChunkBody} from './wav-packets';
+
+class WAVFile {
+    encode (intSamples, {channels = 1, sampleRate = 22050} = {}) {
+        const samplesUint8 = new Uint8Array(intSamples.buffer, intSamples.byteOffset, intSamples.byteLength);
+        const size = (
+            WAVESignature.size +
+            WAVEChunkStart.size +
+            WAVEFMTChunkBody.size +
+            WAVEChunkStart.size +
+            samplesUint8.length
+        );
+
+        const stream = new ByteStream(new ArrayBuffer(size));
+
+        stream.writeStruct(WAVESignature, {
+            riff: 'RIFF',
+            length: size - 8,
+            wave: 'WAVE'
+        });
+
+        stream.writeStruct(WAVEChunkStart, {
+            chunkType: 'fmt ',
+            length: WAVEFMTChunkBody.size
+        });
+
+        stream.writeStruct(WAVEFMTChunkBody, {
+            format: 1,
+            channels: channels,
+            sampleRate: sampleRate,
+            bytesPerSec: sampleRate * 2 * channels,
+            blockAlignment: channels * 2,
+            bitsPerSample: 16
+        });
+
+        stream.writeStruct(WAVEChunkStart, {
+            chunkType: 'data',
+            length: size - stream.position - WAVEChunkStart.size
+        });
+
+        stream.writeBytes(samplesUint8);
+
+        return stream.uint8a;
+    }
+
+    static encode (intSamples, options) {
+        return new WAVFile().encode(intSamples, options);
+    }
+
+    static samples (bytes) {
+        const headerLength = new WAVEChunkStart(bytes, WAVESignature.size).length;
+        const bodyLength = new WAVEChunkStart(bytes, WAVESignature.size + WAVEChunkStart.size + headerLength).length;
+        return bodyLength / 2;
+    }
+}
+
+export {WAVFile};

--- a/src/coders/wav-packets.js
+++ b/src/coders/wav-packets.js
@@ -1,0 +1,34 @@
+import {Packet} from './byte-packets';
+import {Uint16LE, Uint32LE, FixedAsciiString} from './byte-primitives';
+
+class WAVESignature extends Packet.extend({
+    riff: new FixedAsciiString(4),
+    length: Uint32LE,
+    wave: new FixedAsciiString(4)
+}) {}
+
+Packet.initConstructor(WAVESignature);
+
+export {WAVESignature};
+
+class WAVEChunkStart extends Packet.extend({
+    chunkType: new FixedAsciiString(4),
+    length: Uint32LE
+}) {}
+
+Packet.initConstructor(WAVEChunkStart);
+
+export {WAVEChunkStart};
+
+class WAVEFMTChunkBody extends Packet.extend({
+    format: Uint16LE,
+    channels: Uint16LE,
+    sampleRate: Uint32LE,
+    bytesPerSec: Uint32LE,
+    blockAlignment: Uint16LE,
+    bitsPerSample: Uint16LE
+}) {}
+
+Packet.initConstructor(WAVEFMTChunkBody);
+
+export {WAVEFMTChunkBody};

--- a/src/playground/field-object.js
+++ b/src/playground/field-object.js
@@ -1,3 +1,6 @@
+import {PNGFile} from '../coders/png-file';
+import {WAVFile} from '../coders/wav-file';
+
 import {FieldObject} from '../squeak/field-object';
 
 import {ObjectRenderer} from './object';
@@ -15,9 +18,42 @@ class FieldObjectRenderer {
         return data instanceof FieldObject;
     }
 
+    addOptionalPreview (obj) {
+        if (obj.decoded) {
+            let mime;
+            let tag;
+            let encoded;
+            if (obj.extension === 'uncompressed') {
+                mime = 'image/png';
+                tag = new Image();
+                encoded = new Uint8Array(PNGFile.encode(
+                    obj.width,
+                    obj.height,
+                    obj.decoded
+                ));
+            } else if (obj.extension === 'jpg') {
+                mime = 'image/jpg';
+                tag = new Image();
+                encoded = obj.decoded;
+            } else if (obj.extension === 'pcm') {
+                mime = 'audio/wav';
+                tag = new Audio();
+                tag.controls = true;
+                encoded = new Uint8Array(WAVFile.encode(obj.decoded, {
+                    sampleRate: obj.rate && obj.rate.value
+                }));
+            }
+
+            tag.src = URL.createObjectURL(new Blob([encoded.buffer], {type: mime}));
+
+            obj.preview = tag;
+        }
+        return obj;
+    }
+
     render (data, view) {
         new ObjectRenderer().render(
-            Object.assign(() => (
+            Object.assign(() => this.addOptionalPreview(
                 Object.entries(
                     allPropertyDescriptors(Object.getPrototypeOf(data))
                 )


### PR DESCRIPTION
Live playground: https://mzgoddard.github.io/scratch-sb1-converter/squeak-assets/

- Add hashing objects: Adler32 and CRC32
- Add Squeak image decoding (proprietary runs of 1 color, 1-8 bit colormaps, 16 and 32 bit)
- Add Squeak audio decoding (ADPCM 2-5 bit compression)
- Convert ImageMediaData's (costumes) and SoundMediaData's (sounds) rawBytes into uncompressed bitmaps and 16-bit integer samples
- Preview FieldObjects with `.decoded` member as uncompressed PNGs with an Image tag (ImageData and ImageMediaData) or as uncompressed PCM WAVs with an Audio tag (SoundMediaData)

### Image and Sound decoding

Following the decoders in https://github.com/llk/scratch-flash, the image and audio decoding port that code to javascript with changes for TypedArrays and linting.

ImageData and SoundMediaData FieldObject types use the decoders to turn the data into RGBA 32 bit image bitmaps and 16 bit integer audio samples.

### PNG and WAV encoding

There is not yet a browser API that will encode some audio sample format (like custom floating point samples used for Web Audio) into a common disk format like WAV, MP3, or OGG. `scratch-gui` handles this with the npm `wav-encoder` package. At the time of the original authorship of this PR's content I wrote a quick WAV encoder having not yet dug enough into scratch-gui to note its use of wav-encoder.

Following the WAV encoder I wrote an uncompressed PNG encoder keeping external dependencies to a minimum.

At this point we may swap out these two internal implentations for external libraries or browser apis like Canvas2DRenderingContext.toBlob.

### TODO

- [x] Update live playground url
<del>- [ ] Documentation!</del>
<del>- [ ] Tests!</del>
Documentation and tests will be in a follow up PR.
