### PR TITLE
convert `.sb` data to sb2 json and `.sb` assets into a FakeZip with PNGs and WAVs

### DIFF
--- a/src/coders/adler32.js
+++ b/src/coders/adler32.js
@@ -1,0 +1,22 @@
+class Adler32 {
+    constructor () {
+        this.adler = 1;
+    }
+
+    update (uint8a, position, length) {
+        let a = this.adler & 0xffff;
+        let b = this.adler >>> 16;
+        for (let i = 0; i < length; i++) {
+            a = (a + uint8a[position + i]) % 65521;
+            b = (b + a) % 65521;
+        }
+        this.adler = (b << 16) | a;
+        return this;
+    }
+
+    get digest () {
+        return this.adler;
+    }
+}
+
+export {Adler32};

--- a/src/coders/byte-packets.js
+++ b/src/coders/byte-packets.js
@@ -1,6 +1,6 @@
 class Packet {
-    constructor (uint8 = new Uint8Array(this.size), offset = 0) {
-        this.uint8 = uint8;
+    constructor (uint8a = new Uint8Array(this.size), offset = 0) {
+        this.uint8a = uint8a;
         this.offset = offset;
     }
 

--- a/src/coders/byte-primitives.js
+++ b/src/coders/byte-primitives.js
@@ -36,11 +36,11 @@ class BytePrimitive {
 
         return {
             get () {
-                return _this.read(this.uint8, position + this.offset);
+                return _this.read(this.uint8a, position + this.offset);
             },
 
             set (value) {
-                return _this.write(this.uint8, position + this.offset, value);
+                return _this.write(this.uint8a, position + this.offset, value);
             },
 
             enumerable: true
@@ -50,11 +50,11 @@ class BytePrimitive {
 
 const Uint8 = new BytePrimitive({
     size: 1,
-    read (uint8, position) {
-        return uint8[position];
+    read (uint8a, position) {
+        return uint8a[position];
     },
-    write (uint8, position, value) {
-        uint8[position] = value;
+    write (uint8a, position, value) {
+        uint8a[position] = value;
         return value;
     }
 });
@@ -62,30 +62,30 @@ const Uint8 = new BytePrimitive({
 const HOSTLE_BE16 = {
     size: 2,
     // toBytes: Defined by instance.
-    read (uint8, position) {
-        this.bytes[1] = uint8[position + 0];
-        this.bytes[0] = uint8[position + 1];
+    read (uint8a, position) {
+        this.bytes[1] = uint8a[position + 0];
+        this.bytes[0] = uint8a[position + 1];
         return this.toBytes[0];
     },
-    write (uint8, position, value) {
+    write (uint8a, position, value) {
         this.toBytes[0] = value;
-        uint8[position + 0] = this.bytes[1];
-        uint8[position + 1] = this.bytes[0];
+        uint8a[position + 0] = this.bytes[1];
+        uint8a[position + 1] = this.bytes[0];
         return value;
     }
 };
 const HOSTBE_BE16 = {
     size: 2,
     // toBytes: Defined by instance.
-    read (uint8, position) {
-        this.bytes[0] = uint8[position + 0];
-        this.bytes[1] = uint8[position + 1];
+    read (uint8a, position) {
+        this.bytes[0] = uint8a[position + 0];
+        this.bytes[1] = uint8a[position + 1];
         return this.toBytes[0];
     },
-    write (uint8, position, value) {
+    write (uint8a, position, value) {
         this.toBytes[0] = value;
-        uint8[position + 0] = this.bytes[0];
-        uint8[position + 1] = this.bytes[1];
+        uint8a[position + 0] = this.bytes[0];
+        uint8a[position + 1] = this.bytes[1];
         return value;
     }
 };
@@ -108,38 +108,38 @@ const Int16BE = new BytePrimitive(Object.assign({}, BE16, {
 const HOSTLE_BE32 = {
     size: 4,
     // toBytes: Defined by instance.
-    read (uint8, position) {
-        this.bytes[3] = uint8[position + 0];
-        this.bytes[2] = uint8[position + 1];
-        this.bytes[1] = uint8[position + 2];
-        this.bytes[0] = uint8[position + 3];
+    read (uint8a, position) {
+        this.bytes[3] = uint8a[position + 0];
+        this.bytes[2] = uint8a[position + 1];
+        this.bytes[1] = uint8a[position + 2];
+        this.bytes[0] = uint8a[position + 3];
         return this.toBytes[0];
     },
-    write (uint8, position, value) {
+    write (uint8a, position, value) {
         this.toBytes[0] = value;
-        uint8[position + 0] = this.bytes[3];
-        uint8[position + 1] = this.bytes[2];
-        uint8[position + 2] = this.bytes[1];
-        uint8[position + 3] = this.bytes[0];
+        uint8a[position + 0] = this.bytes[3];
+        uint8a[position + 1] = this.bytes[2];
+        uint8a[position + 2] = this.bytes[1];
+        uint8a[position + 3] = this.bytes[0];
         return value;
     }
 };
 const HOSTBE_BE32 = {
     size: 4,
     // toBytes: Defined by instance.
-    read (uint8, position) {
-        this.bytes[0] = uint8[position + 0];
-        this.bytes[1] = uint8[position + 1];
-        this.bytes[2] = uint8[position + 2];
-        this.bytes[3] = uint8[position + 3];
+    read (uint8a, position) {
+        this.bytes[0] = uint8a[position + 0];
+        this.bytes[1] = uint8a[position + 1];
+        this.bytes[2] = uint8a[position + 2];
+        this.bytes[3] = uint8a[position + 3];
         return this.toBytes[0];
     },
-    write (uint8, position, value) {
+    write (uint8a, position, value) {
         this.toBytes[0] = value;
-        uint8[position + 0] = this.bytes[0];
-        uint8[position + 1] = this.bytes[1];
-        uint8[position + 2] = this.bytes[2];
-        uint8[position + 3] = this.bytes[3];
+        uint8a[position + 0] = this.bytes[0];
+        uint8a[position + 1] = this.bytes[1];
+        uint8a[position + 2] = this.bytes[2];
+        uint8a[position + 3] = this.bytes[3];
         return value;
     }
 };
@@ -183,30 +183,30 @@ const Uint32LE = new BytePrimitive(Object.assign({}, LE32, {
 
 const HOSTLE_BEDOUBLE = {
     size: 8,
-    read (uint8, position) {
-        this.bytes[7] = uint8[position + 0];
-        this.bytes[6] = uint8[position + 1];
-        this.bytes[5] = uint8[position + 2];
-        this.bytes[4] = uint8[position + 3];
-        this.bytes[3] = uint8[position + 4];
-        this.bytes[2] = uint8[position + 5];
-        this.bytes[1] = uint8[position + 6];
-        this.bytes[0] = uint8[position + 7];
+    read (uint8a, position) {
+        this.bytes[7] = uint8a[position + 0];
+        this.bytes[6] = uint8a[position + 1];
+        this.bytes[5] = uint8a[position + 2];
+        this.bytes[4] = uint8a[position + 3];
+        this.bytes[3] = uint8a[position + 4];
+        this.bytes[2] = uint8a[position + 5];
+        this.bytes[1] = uint8a[position + 6];
+        this.bytes[0] = uint8a[position + 7];
         return this.toBytes[0];
     }
 };
 
 const HOSTBE_BEDOUBLE = {
     size: 8,
-    read (uint8, position) {
-        this.bytes[7] = uint8[position + 0];
-        this.bytes[6] = uint8[position + 1];
-        this.bytes[5] = uint8[position + 2];
-        this.bytes[4] = uint8[position + 3];
-        this.bytes[3] = uint8[position + 4];
-        this.bytes[2] = uint8[position + 5];
-        this.bytes[1] = uint8[position + 6];
-        this.bytes[0] = uint8[position + 7];
+    read (uint8a, position) {
+        this.bytes[7] = uint8a[position + 0];
+        this.bytes[6] = uint8a[position + 1];
+        this.bytes[5] = uint8a[position + 2];
+        this.bytes[4] = uint8a[position + 3];
+        this.bytes[3] = uint8a[position + 4];
+        this.bytes[2] = uint8a[position + 5];
+        this.bytes[1] = uint8a[position + 6];
+        this.bytes[0] = uint8a[position + 7];
         return this.toBytes[0];
     }
 };
@@ -226,20 +226,20 @@ class FixedAsciiString extends BytePrimitive {
     constructor (size) {
         super({
             size,
-            read (uint8, position) {
+            read (uint8a, position) {
                 let str = '';
                 for (let i = 0; i < size; i++) {
-                    const code = uint8[position + i];
+                    const code = uint8a[position + i];
                     assert(code <= 127, 'Non-ascii character in FixedAsciiString');
                     str += String.fromCharCode(code);
                 }
                 return str;
             },
-            write (uint8, position, value) {
+            write (uint8a, position, value) {
                 for (let i = 0; i < size; i++) {
                     const code = value.charCodeAt(i);
                     assert(code <= 127, 'Non-ascii character in FixedAsciiString');
-                    uint8[position + i] = code;
+                    uint8a[position + i] = code;
                 }
                 return value;
             }

--- a/src/coders/byte-stream.js
+++ b/src/coders/byte-stream.js
@@ -5,13 +5,13 @@ class ByteStream {
         this.buffer = buffer;
         this.position = position;
 
-        this.uint8 = new Uint8Array(this.buffer);
+        this.uint8a = new Uint8Array(this.buffer);
     }
 
     read (member) {
-        const value = member.read(this.uint8, this.position);
+        const value = member.read(this.uint8a, this.position);
         if (member.size === 0) {
-            this.position += member.sizeOf(this.uint8, this.position);
+            this.position += member.sizeOf(this.uint8a, this.position);
         } else {
             this.position += member.size;
         }
@@ -19,19 +19,19 @@ class ByteStream {
     }
 
     readStruct (StructType) {
-        const obj = new StructType(this.uint8, this.position);
+        const obj = new StructType(this.uint8a, this.position);
         this.position += StructType.size;
         return obj;
     }
 
     resize (needed) {
         if (this.buffer.byteLength < needed) {
-            const uint8 = this.uint8;
+            const uint8a = this.uint8a;
             const nextPowerOf2 = Math.pow(2, Math.ceil(Math.log(needed) / Math.log(2)));
             this.buffer = new ArrayBuffer(nextPowerOf2);
 
-            this.uint8 = new Uint8Array(this.buffer);
-            this.uint8.set(uint8);
+            this.uint8a = new Uint8Array(this.buffer);
+            this.uint8a.set(uint8a);
         }
     }
 
@@ -42,9 +42,9 @@ class ByteStream {
             this.resize(this.position + member.size);
         }
 
-        member.write(this.uint8, this.position, value);
+        member.write(this.uint8a, this.position, value);
         if (member.size === 0) {
-            this.position += member.writeSizeOf(this.uint8, this.position);
+            this.position += member.writeSizeOf(this.uint8a, this.position);
         } else {
             this.position += member.size;
         }
@@ -54,7 +54,7 @@ class ByteStream {
     writeStruct (StructType, data) {
         this.resize(this.position + StructType.size);
 
-        const st = Object.assign(new StructType(this.uint8, this.position), data);
+        const st = Object.assign(new StructType(this.uint8a, this.position), data);
         this.position += StructType.size;
         return st;
     }
@@ -65,7 +65,7 @@ class ByteStream {
         this.resize(this.position + (end - start));
 
         for (let i = start; i < end; i++) {
-            this.uint8[this.position + i - start] = bytes[i];
+            this.uint8a[this.position + i - start] = bytes[i];
         }
         this.position += end - start;
         return bytes;

--- a/src/coders/crc32.js
+++ b/src/coders/crc32.js
@@ -1,0 +1,32 @@
+class CRC32 {
+    constructor () {
+        this.bit = new Uint32Array(1);
+        this.crc = 0;
+        this.c = 0;
+
+        this.table = [];
+        let c;
+        for (let i = 0; i < 256; i++) {
+            c = i;
+            for (let j = 0; j < 8; j++) {
+                c = (c & 1) ? (0xedb88320 ^ (c >>> 1)) : (c >>> 1);
+            }
+            this.table[i] = c >>> 0;
+        }
+    }
+
+    update (uint8a, position = 0, length = uint8a.length) {
+        let crc = (~this.crc) >>> 0;
+        for (let i = 0; i < length; i++) {
+            crc = (crc >>> 8) ^ this.table[(crc ^ uint8a[position + i]) & 0xff];
+        }
+        this.crc = (~crc) >>> 0;
+        return this;
+    }
+
+    get digest () {
+        return this.crc;
+    }
+}
+
+export {CRC32};

--- a/src/coders/deflate-packets.js
+++ b/src/coders/deflate-packets.js
@@ -1,0 +1,33 @@
+import {Packet} from './byte-packets';
+import {Uint8, Uint16LE, Uint32LE} from './byte-primitives';
+
+const DEFLATE_BLOCK_SIZE_MAX = 0xffff;
+
+export {DEFLATE_BLOCK_SIZE_MAX};
+
+class DeflateHeader extends Packet.extend({
+    cmf: Uint8,
+    flag: Uint8
+}) {}
+
+Packet.initConstructor(DeflateHeader);
+
+export {DeflateHeader};
+
+class DeflateChunkStart extends Packet.extend({
+    lastPacket: Uint8,
+    length: Uint16LE,
+    lengthCheck: Uint16LE
+}) {}
+
+Packet.initConstructor(DeflateChunkStart);
+
+export {DeflateChunkStart};
+
+class DeflateEnd extends Packet.extend({
+    checksum: Uint32LE
+}) {}
+
+Packet.initConstructor(DeflateEnd);
+
+export {DeflateEnd};

--- a/src/coders/deflate-stream.js
+++ b/src/coders/deflate-stream.js
@@ -1,0 +1,79 @@
+import {Adler32} from './adler32';
+import {DEFLATE_BLOCK_SIZE_MAX, DeflateHeader, DeflateChunkStart, DeflateEnd} from './deflate-packets';
+import {ProxyStream} from './proxy-stream';
+
+class DeflateStream extends ProxyStream {
+    constructor (stream) {
+        super(stream);
+
+        this.stream.writeStruct(DeflateHeader, {
+            cmf: 0b00001000,
+            flag: 0b00011101
+        });
+
+        this.adler = new Adler32();
+
+        this.chunk = this.stream.writeStruct(DeflateChunkStart, {
+            lastPacket: 0,
+            length: 0,
+            lengthCheck: 0 ^ 0xffff
+        });
+    }
+
+    get _deflateIndex () {
+        return this.chunk.length;
+    }
+
+    set _deflateIndex (value) {
+        this.chunk.length = value;
+        this.chunk.lengthCheck = value ^ 0xffff;
+        return this.chunk.length;
+    }
+
+    writeStruct (StructType, data) {
+        this.writeBytes(Object.assign(new StructType(), data).uint8a);
+    }
+
+    writeBytes (bytes, start = 0, end = bytes.length) {
+        let chunkStart = start;
+        while (end - chunkStart > 0) {
+            if (this._deflateIndex === DEFLATE_BLOCK_SIZE_MAX) {
+                this.chunk = this.stream.writeStruct(DeflateChunkStart, {
+                    lastPacket: 0,
+                    length: 0,
+                    lengthCheck: 0 ^ 0xffff
+                });
+            }
+
+            const chunkLength = Math.min(
+                end - chunkStart,
+                DEFLATE_BLOCK_SIZE_MAX - this._deflateIndex
+            );
+            this.stream.writeBytes(bytes, chunkStart, chunkStart + chunkLength);
+            this._deflateIndex += chunkLength;
+            chunkStart += chunkLength;
+        }
+
+        this.adler.update(bytes, start, end - start);
+    }
+
+    finish () {
+        this.chunk.lastPacket = 1;
+
+        this.stream.writeStruct(DeflateEnd, {
+            checksum: this.adler.digest
+        });
+    }
+
+    static estimateSize (bodySize) {
+        const packets = Math.ceil(bodySize / DEFLATE_BLOCK_SIZE_MAX);
+        return (
+            DeflateHeader.size +
+            (packets * DeflateChunkStart.size) +
+            DeflateEnd.size +
+            bodySize
+        );
+    }
+}
+
+export {DeflateStream};

--- a/src/coders/png-chunk-stream.js
+++ b/src/coders/png-chunk-stream.js
@@ -1,0 +1,34 @@
+import {Uint32BE} from './byte-primitives';
+import {CRC32} from './crc32';
+import {PNGChunkStart, PNGChunkEnd} from './png-packets';
+import {ProxyStream} from './proxy-stream';
+
+class PNGChunkStream extends ProxyStream {
+    constructor (stream, chunkType = 'IHDR') {
+        super(stream);
+
+        this.start = this.stream.writeStruct(PNGChunkStart, {
+            length: 0,
+            chunkType
+        });
+
+        this.crc = new CRC32();
+    }
+
+    finish () {
+        const crcStart = this.start.offset + this.start.size;
+        const length = this.position - crcStart;
+        this.start.length = length;
+
+        this.crc.update(this.stream.uint8a, crcStart - Uint32BE.size, length + Uint32BE.size);
+        this.stream.writeStruct(PNGChunkEnd, {
+            checksum: this.crc.digest
+        });
+    }
+
+    static size (bodySize) {
+        return PNGChunkStart.size + bodySize + PNGChunkEnd.size;
+    }
+}
+
+export {PNGChunkStream};

--- a/src/coders/png-file.js
+++ b/src/coders/png-file.js
@@ -1,0 +1,81 @@
+import {ByteStream} from './byte-stream';
+import {PNGSignature, PNGIHDRChunkBody, PNGFilterMethodByte} from './png-packets';
+import {DeflateStream} from './deflate-stream';
+import {PNGChunkStream} from './png-chunk-stream';
+
+class PNGFile {
+    encode (width, height, pixelsUint8) {
+        const rowSize = (width * 4) + PNGFilterMethodByte.size;
+        const bodySize = rowSize * height;
+        const size = (
+            PNGSignature.size +
+            // IHDR
+            PNGChunkStream.size(PNGIHDRChunkBody.size) +
+            // IDAT
+            PNGChunkStream.size(DeflateStream.estimateSize(bodySize)) +
+            // IEND
+            PNGChunkStream.size(0)
+        );
+
+        const stream = new ByteStream(new ArrayBuffer(size));
+
+        stream.writeStruct(PNGSignature, {
+            support8Bit: 0x89,
+            png: 'PNG',
+            dosLineEnding: '\r\n',
+            dosEndOfFile: '\x1a',
+            unixLineEnding: '\n'
+        });
+
+        const pngIhdr = new PNGChunkStream(stream, 'IHDR');
+
+        pngIhdr.writeStruct(PNGIHDRChunkBody, {
+            width,
+            height,
+            bitDepth: 8,
+            colorType: 6,
+            compressionMethod: 0,
+            filterMethod: 0,
+            interlaceMethod: 0
+        });
+
+        pngIhdr.finish();
+
+        const pngIdat = new PNGChunkStream(stream, 'IDAT');
+
+        const deflate = new DeflateStream(pngIdat);
+
+        let pixelsIndex = 0;
+        while (pixelsIndex < pixelsUint8.length) {
+            deflate.writeStruct(PNGFilterMethodByte, {
+                method: 0
+            });
+
+            const partialLength = Math.min(
+                pixelsUint8.length - pixelsIndex,
+                rowSize - PNGFilterMethodByte.size
+            );
+            deflate.writeBytes(
+                pixelsUint8, pixelsIndex, pixelsIndex + partialLength
+            );
+
+            pixelsIndex += partialLength;
+        }
+
+        deflate.finish();
+
+        pngIdat.finish();
+
+        const pngIend = new PNGChunkStream(stream, 'IEND');
+
+        pngIend.finish();
+
+        return stream.buffer;
+    }
+
+    static encode (width, height, pixels) {
+        return new PNGFile().encode(width, height, pixels);
+    }
+}
+
+export {PNGFile};

--- a/src/coders/png-packets.js
+++ b/src/coders/png-packets.js
@@ -1,0 +1,65 @@
+import {assert} from '../util/assert';
+
+import {Packet} from './byte-packets';
+import {Uint8, Uint32BE, FixedAsciiString} from './byte-primitives';
+
+class PNGSignature extends Packet.extend({
+    support8Bit: Uint8,
+    png: new FixedAsciiString(3),
+    dosLineEnding: new FixedAsciiString(2),
+    dosEndOfFile: new FixedAsciiString(1),
+    unixLineEnding: new FixedAsciiString(1)
+}) {
+    static validate () {
+        assert(this.equals({
+            support8Bit: 0x89,
+            png: 'PNG',
+            dosLineEnding: '\r\n',
+            dosEndOfFile: '\x1a',
+            unixLineEnding: '\n'
+        }), 'PNGSignature does not match the expected values');
+    }
+}
+
+Packet.initConstructor(PNGSignature);
+
+export {PNGSignature};
+
+class PNGChunkStart extends Packet.extend({
+    length: Uint32BE,
+    chunkType: new FixedAsciiString(4)
+}) {}
+
+Packet.initConstructor(PNGChunkStart);
+
+export {PNGChunkStart};
+
+class PNGChunkEnd extends Packet.extend({
+    checksum: Uint32BE
+}) {}
+
+Packet.initConstructor(PNGChunkEnd);
+
+export {PNGChunkEnd};
+
+class PNGIHDRChunkBody extends Packet.extend({
+    width: Uint32BE,
+    height: Uint32BE,
+    bitDepth: Uint8,
+    colorType: Uint8,
+    compressionMethod: Uint8,
+    filterMethod: Uint8,
+    interlaceMethod: Uint8
+}) {}
+
+Packet.initConstructor(PNGIHDRChunkBody);
+
+export {PNGIHDRChunkBody};
+
+class PNGFilterMethodByte extends Packet.extend({
+    method: Uint8
+}) {}
+
+Packet.initConstructor(PNGFilterMethodByte);
+
+export {PNGFilterMethodByte};

--- a/src/coders/proxy-stream.js
+++ b/src/coders/proxy-stream.js
@@ -1,0 +1,33 @@
+class ProxyStream {
+    constructor (stream) {
+        this.stream = stream;
+    }
+
+    get uint8a () {
+        return this.stream.uint8a;
+    }
+
+    set uint8a (value) {
+        this.stream.uint8a = value;
+        return this.stream.uint8a;
+    }
+
+    get position () {
+        return this.stream.position;
+    }
+
+    set position (value) {
+        this.stream.position = value;
+        return this.stream.position;
+    }
+
+    writeStruct (StructType, data) {
+        return this.stream.writeStruct(StructType, data);
+    }
+
+    writeBytes (bytes, start = 0, end = bytes.length) {
+        return this.stream.writeBytes(bytes, start, end);
+    }
+}
+
+export {ProxyStream};

--- a/src/coders/squeak-image.js
+++ b/src/coders/squeak-image.js
@@ -1,0 +1,200 @@
+import {BytePrimitive, Uint8, Uint32BE} from './byte-primitives';
+import {ByteStream} from './byte-stream';
+
+const defaultColorMap = [
+    0x00000000, 0xFF000000, 0xFFFFFFFF, 0xFF808080, 0xFFFF0000, 0xFF00FF00, 0xFF0000FF, 0xFF00FFFF,
+    0xFFFFFF00, 0xFFFF00FF, 0xFF202020, 0xFF404040, 0xFF606060, 0xFF9F9F9F, 0xFFBFBFBF, 0xFFDFDFDF,
+    0xFF080808, 0xFF101010, 0xFF181818, 0xFF282828, 0xFF303030, 0xFF383838, 0xFF484848, 0xFF505050,
+    0xFF585858, 0xFF686868, 0xFF707070, 0xFF787878, 0xFF878787, 0xFF8F8F8F, 0xFF979797, 0xFFA7A7A7,
+    0xFFAFAFAF, 0xFFB7B7B7, 0xFFC7C7C7, 0xFFCFCFCF, 0xFFD7D7D7, 0xFFE7E7E7, 0xFFEFEFEF, 0xFFF7F7F7,
+    0xFF000000, 0xFF003300, 0xFF006600, 0xFF009900, 0xFF00CC00, 0xFF00FF00, 0xFF000033, 0xFF003333,
+    0xFF006633, 0xFF009933, 0xFF00CC33, 0xFF00FF33, 0xFF000066, 0xFF003366, 0xFF006666, 0xFF009966,
+    0xFF00CC66, 0xFF00FF66, 0xFF000099, 0xFF003399, 0xFF006699, 0xFF009999, 0xFF00CC99, 0xFF00FF99,
+    0xFF0000CC, 0xFF0033CC, 0xFF0066CC, 0xFF0099CC, 0xFF00CCCC, 0xFF00FFCC, 0xFF0000FF, 0xFF0033FF,
+    0xFF0066FF, 0xFF0099FF, 0xFF00CCFF, 0xFF00FFFF, 0xFF330000, 0xFF333300, 0xFF336600, 0xFF339900,
+    0xFF33CC00, 0xFF33FF00, 0xFF330033, 0xFF333333, 0xFF336633, 0xFF339933, 0xFF33CC33, 0xFF33FF33,
+    0xFF330066, 0xFF333366, 0xFF336666, 0xFF339966, 0xFF33CC66, 0xFF33FF66, 0xFF330099, 0xFF333399,
+    0xFF336699, 0xFF339999, 0xFF33CC99, 0xFF33FF99, 0xFF3300CC, 0xFF3333CC, 0xFF3366CC, 0xFF3399CC,
+    0xFF33CCCC, 0xFF33FFCC, 0xFF3300FF, 0xFF3333FF, 0xFF3366FF, 0xFF3399FF, 0xFF33CCFF, 0xFF33FFFF,
+    0xFF660000, 0xFF663300, 0xFF666600, 0xFF669900, 0xFF66CC00, 0xFF66FF00, 0xFF660033, 0xFF663333,
+    0xFF666633, 0xFF669933, 0xFF66CC33, 0xFF66FF33, 0xFF660066, 0xFF663366, 0xFF666666, 0xFF669966,
+    0xFF66CC66, 0xFF66FF66, 0xFF660099, 0xFF663399, 0xFF666699, 0xFF669999, 0xFF66CC99, 0xFF66FF99,
+    0xFF6600CC, 0xFF6633CC, 0xFF6666CC, 0xFF6699CC, 0xFF66CCCC, 0xFF66FFCC, 0xFF6600FF, 0xFF6633FF,
+    0xFF6666FF, 0xFF6699FF, 0xFF66CCFF, 0xFF66FFFF, 0xFF990000, 0xFF993300, 0xFF996600, 0xFF999900,
+    0xFF99CC00, 0xFF99FF00, 0xFF990033, 0xFF993333, 0xFF996633, 0xFF999933, 0xFF99CC33, 0xFF99FF33,
+    0xFF990066, 0xFF993366, 0xFF996666, 0xFF999966, 0xFF99CC66, 0xFF99FF66, 0xFF990099, 0xFF993399,
+    0xFF996699, 0xFF999999, 0xFF99CC99, 0xFF99FF99, 0xFF9900CC, 0xFF9933CC, 0xFF9966CC, 0xFF9999CC,
+    0xFF99CCCC, 0xFF99FFCC, 0xFF9900FF, 0xFF9933FF, 0xFF9966FF, 0xFF9999FF, 0xFF99CCFF, 0xFF99FFFF,
+    0xFFCC0000, 0xFFCC3300, 0xFFCC6600, 0xFFCC9900, 0xFFCCCC00, 0xFFCCFF00, 0xFFCC0033, 0xFFCC3333,
+    0xFFCC6633, 0xFFCC9933, 0xFFCCCC33, 0xFFCCFF33, 0xFFCC0066, 0xFFCC3366, 0xFFCC6666, 0xFFCC9966,
+    0xFFCCCC66, 0xFFCCFF66, 0xFFCC0099, 0xFFCC3399, 0xFFCC6699, 0xFFCC9999, 0xFFCCCC99, 0xFFCCFF99,
+    0xFFCC00CC, 0xFFCC33CC, 0xFFCC66CC, 0xFFCC99CC, 0xFFCCCCCC, 0xFFCCFFCC, 0xFFCC00FF, 0xFFCC33FF,
+    0xFFCC66FF, 0xFFCC99FF, 0xFFCCCCFF, 0xFFCCFFFF, 0xFFFF0000, 0xFFFF3300, 0xFFFF6600, 0xFFFF9900,
+    0xFFFFCC00, 0xFFFFFF00, 0xFFFF0033, 0xFFFF3333, 0xFFFF6633, 0xFFFF9933, 0xFFFFCC33, 0xFFFFFF33,
+    0xFFFF0066, 0xFFFF3366, 0xFFFF6666, 0xFFFF9966, 0xFFFFCC66, 0xFFFFFF66, 0xFFFF0099, 0xFFFF3399,
+    0xFFFF6699, 0xFFFF9999, 0xFFFFCC99, 0xFFFFFF99, 0xFFFF00CC, 0xFFFF33CC, 0xFFFF66CC, 0xFFFF99CC,
+    0xFFFFCCCC, 0xFFFFFFCC, 0xFFFF00FF, 0xFFFF33FF, 0xFFFF66FF, 0xFFFF99FF, 0xFFFFCCFF, 0xFFFFFFFF];
+
+const defaultOneBitColorMap = [0xFFFFFFFF, 0xFF000000];
+
+const VariableIntBE = new BytePrimitive({
+    sizeOf (uint8a, position) {
+        const count = uint8a[position];
+        if (count <= 223) return 1;
+        if (count <= 254) return 2;
+        return 5;
+    },
+    read (uint8a, position) {
+        const count = uint8a[position];
+        if (count <= 223) return count;
+        if (count <= 254) return ((count - 224) * 256) + uint8a[position + 1];
+        return Uint32BE.read(uint8a, position + 1);
+    }
+});
+
+class SqueakImage {
+    decode (width, height, depth, bytes, colormap) {
+        const pixels = this.decodePixels(bytes, depth === 32);
+
+        if (depth <= 8) {
+            if (!colormap) {
+                colormap = depth === 1 ? defaultOneBitColorMap : defaultColorMap;
+            }
+            return this.unpackPixels(pixels, width, height, depth, colormap);
+        } else if (depth === 16) {
+            return this.raster16To32(pixels, width, height);
+        } else if (depth === 32) {
+            return pixels;
+        }
+        throw new Error('Unhandled Squeak Image depth.');
+    }
+
+    decodePixels (bytes, withAlpha) {
+        let result;
+
+        // Already decompressed
+        if (Array.isArray(bytes) || bytes instanceof Uint32Array) {
+            result = new Uint32Array(bytes);
+            if (withAlpha) {
+                for (let i = 0; i < result.length; i++) {
+                    if (result[i] !== 0) {
+                        result[i] = 0xff000000 | result[i];
+                    }
+                }
+            }
+            return result;
+        }
+
+        const stream = new ByteStream(bytes.buffer, bytes.byteOffset);
+
+        const pixelsOut = stream.read(VariableIntBE);
+        result = new Uint32Array(pixelsOut);
+
+        let i = 0;
+        while (i < pixelsOut) {
+            const runLengthAndCode = stream.read(VariableIntBE);
+            const runLength = runLengthAndCode >> 2;
+            const code = runLengthAndCode & 0b11;
+
+            let w;
+
+            switch (code) {
+            case 0:
+                i += runLength;
+                break;
+
+            case 1:
+                w = stream.read(Uint8);
+                w = (w << 24) | (w << 16) | (w << 8) | w;
+                if (withAlpha && w !== 0) {
+                    w |= 0xff000000;
+                }
+                for (let j = 0; j < runLength; j++) {
+                    result[i++] = w;
+                }
+                break;
+
+            case 2:
+                w = stream.read(Uint32BE);
+                if (withAlpha && w !== 0) {
+                    w |= 0xff000000;
+                }
+                for (let j = 0; j < runLength; j++) {
+                    result[i++] = w;
+                }
+                break;
+
+            case 3:
+                for (let j = 0; j < runLength; j++) {
+                    w = stream.read(Uint32BE);
+                    if (withAlpha && w !== 0) {
+                        w |= 0xff000000;
+                    }
+                    result[i++] = w;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    unpackPixels (words, width, height, depth, colormap) {
+        const result = new Uint32Array(width * height);
+        const mask = (1 << depth) - 1;
+        const pixelsPerWord = 32 / depth;
+        let dst = 0;
+
+        let src = 0;
+        for (let y = 0; y < height; y++) {
+            let word;
+            let shift = -1;
+            for (let x = 0; x < width; x++) {
+                if (shift < 0) {
+                    shift = depth * (pixelsPerWord - 1);
+                    word = words[src++];
+                }
+                result[dst++] = colormap[(word >> shift) & mask];
+                shift -= depth;
+            }
+        }
+        return result;
+    }
+
+    raster16To32 (words, width, height) {
+        const result = new Uint32Array(2 * words.length);
+        let shift;
+        let word;
+        let pix;
+        let src = 0;
+        let dst = 0;
+        for (let y = 0; y < height; y++) {
+            shift = -1;
+            for (let x = 0; x < width; x++) {
+                if (shift < 0) {
+                    shift = 16;
+                    word = words[src++];
+                }
+                pix = (word >> shift) & 0xffff;
+                if (pix !== 0) {
+                    const red = (pix >> 7) & 0b11111000;
+                    const green = (pix >> 2) & 0b11111000;
+                    const blue = (pix << 3) & 0b11111000;
+                    pix = 0xff000000 | (red << 16) | (green << 8) | blue;
+                }
+                result[dst++] = pix;
+                shift -= 16;
+            }
+        }
+        return result;
+    }
+
+    buildCustomColormap (depth, colors, table) {
+        const result = new Uint32Array(1 << depth);
+        for (let i = 0; i < colors.length; i++) {
+            result[i] = table[colors[i].index - 1];
+        }
+        return result;
+    }
+}
+
+export {SqueakImage};

--- a/src/coders/squeak-sound.js
+++ b/src/coders/squeak-sound.js
@@ -1,0 +1,114 @@
+import {assert} from '../util/assert';
+
+import {Uint8} from './byte-primitives';
+import {ByteStream} from './byte-stream';
+
+const SQUEAK_SOUND_STEP_SIZE_TABLE = [
+    7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 19, 21, 23, 25, 28, 31, 34, 37, 41,
+    45, 50, 55, 60, 66, 73, 80, 88, 97, 107, 118, 130, 143, 157, 173, 190, 209,
+    230, 253, 279, 307, 337, 371, 408, 449, 494, 544, 598, 658, 724, 796, 876,
+    963, 1060, 1166, 1282, 1411, 1552, 1707, 1878, 2066, 2272, 2499, 2749,
+    3024, 3327, 3660, 4026, 4428, 4871, 5358, 5894, 6484, 7132, 7845, 8630,
+    9493, 10442, 11487, 12635, 13899, 15289, 16818, 18500, 20350, 22385, 24623,
+    27086, 29794, 32767
+];
+
+const SQUEAK_SOUND_INDEX_TABLES = {
+    2: [-1, 2, -1, 2],
+    3: [-1, -1, 2, 4, -1, -1, 2, 4],
+    4: [-1, -1, -1, -1, 2, 4, 6, 8, -1, -1, -1, -1, 2, 4, 6, 8],
+    5: [
+        -1, -1, -1, -1, -1, -1, -1, -1, 1, 2, 4, 6, 8, 10, 13, 16,
+        -1, -1, -1, -1, -1, -1, -1, -1, 1, 2, 4, 6, 8, 10, 13, 16
+    ]
+};
+
+class SqueakSound {
+    constructor (bitsPerSample) {
+        this.bitsPerSample = bitsPerSample;
+
+        this.indexTable = SQUEAK_SOUND_INDEX_TABLES[bitsPerSample];
+
+        this.signMask = 1 << (bitsPerSample - 1);
+        this.valueMask = this.signMask - 1;
+        this.valueHighBit = this.signMask >> 1;
+
+        this.bitPosition = 0;
+        this.currentByte = 0;
+
+        this.stream = null;
+        this.end = 0;
+    }
+
+    decode (data) {
+        // Reset position information.
+        this.bitPosition = 0;
+        this.currentByte = 0;
+
+        this.stream = new ByteStream(data.buffer, data.byteOffset);
+        this.end = data.byteOffset + data.length;
+
+        const size = Math.floor(data.length * 8 / this.bitsPerSample);
+        const result = new Int16Array(size);
+
+        let sample = 0;
+        let index = 0;
+
+        for (let i = 0; i < size; i++) {
+            const code = this.nextCode();
+
+            assert(code >= 0, 'Ran out of bits in Squeak Sound');
+
+            let step = SQUEAK_SOUND_STEP_SIZE_TABLE[index];
+            let delta = 0;
+            for (let bit = this.valueHighBit; bit > 0; bit = bit >> 1) {
+                if ((code & bit) !== 0) {
+                    delta += step;
+                }
+                step = step >> 1;
+            }
+            delta += step;
+
+            sample += ((code & this.signMask) === 0) ? delta : -delta;
+
+            index += this.indexTable[code];
+            if (index < 0) index = 0;
+            if (index > 88) index = 88;
+
+            if (sample > 32767) sample = 32767;
+            if (sample < -32768) sample = -32768;
+
+            result[i] = sample;
+        }
+
+        return result;
+    }
+
+    nextCode () {
+        let remaining = this.bitsPerSample;
+        let shift = remaining - this.bitPosition;
+        let result = (shift < 0) ? (this.currentByte >> -shift) : (this.currentByte << shift);
+        while (shift > 0) {
+            remaining -= this.bitPosition;
+            if (this.end - this.stream.position > 0) {
+                this.currentByte = this.stream.read(Uint8);
+                this.bitPosition = 8;
+            } else {
+                this.currentByte = 0;
+                this.bitPosition = 0;
+                return -1;
+            }
+            shift = remaining - this.bitPosition;
+            result += (shift < 0) ? (this.currentByte >> -shift) : (this.currentByte << shift);
+        }
+        this.bitPosition -= remaining;
+        this.currentByte = this.currentByte & (0xff >> (8 - this.bitPosition));
+        return result;
+    }
+
+    static samples (bitsPerSample, data) {
+        return data.length * 8 / bitsPerSample;
+    }
+}
+
+export {SqueakSound};

--- a/src/coders/wav-file.js
+++ b/src/coders/wav-file.js
@@ -1,0 +1,58 @@
+import {ByteStream} from './byte-stream';
+import {WAVESignature, WAVEChunkStart, WAVEFMTChunkBody} from './wav-packets';
+
+class WAVFile {
+    encode (intSamples, {channels = 1, sampleRate = 22050} = {}) {
+        const samplesUint8 = new Uint8Array(intSamples.buffer, intSamples.byteOffset, intSamples.byteLength);
+        const size = (
+            WAVESignature.size +
+            WAVEChunkStart.size +
+            WAVEFMTChunkBody.size +
+            WAVEChunkStart.size +
+            samplesUint8.length
+        );
+
+        const stream = new ByteStream(new ArrayBuffer(size));
+
+        stream.writeStruct(WAVESignature, {
+            riff: 'RIFF',
+            length: size - 8,
+            wave: 'WAVE'
+        });
+
+        stream.writeStruct(WAVEChunkStart, {
+            chunkType: 'fmt ',
+            length: WAVEFMTChunkBody.size
+        });
+
+        stream.writeStruct(WAVEFMTChunkBody, {
+            format: 1,
+            channels: channels,
+            sampleRate: sampleRate,
+            bytesPerSec: sampleRate * 2 * channels,
+            blockAlignment: channels * 2,
+            bitsPerSample: 16
+        });
+
+        stream.writeStruct(WAVEChunkStart, {
+            chunkType: 'data',
+            length: size - stream.position - WAVEChunkStart.size
+        });
+
+        stream.writeBytes(samplesUint8);
+
+        return stream.uint8a;
+    }
+
+    static encode (intSamples, options) {
+        return new WAVFile().encode(intSamples, options);
+    }
+
+    static samples (bytes) {
+        const headerLength = new WAVEChunkStart(bytes, WAVESignature.size).length;
+        const bodyLength = new WAVEChunkStart(bytes, WAVESignature.size + WAVEChunkStart.size + headerLength).length;
+        return bodyLength / 2;
+    }
+}
+
+export {WAVFile};

--- a/src/coders/wav-packets.js
+++ b/src/coders/wav-packets.js
@@ -1,0 +1,34 @@
+import {Packet} from './byte-packets';
+import {Uint16LE, Uint32LE, FixedAsciiString} from './byte-primitives';
+
+class WAVESignature extends Packet.extend({
+    riff: new FixedAsciiString(4),
+    length: Uint32LE,
+    wave: new FixedAsciiString(4)
+}) {}
+
+Packet.initConstructor(WAVESignature);
+
+export {WAVESignature};
+
+class WAVEChunkStart extends Packet.extend({
+    chunkType: new FixedAsciiString(4),
+    length: Uint32LE
+}) {}
+
+Packet.initConstructor(WAVEChunkStart);
+
+export {WAVEChunkStart};
+
+class WAVEFMTChunkBody extends Packet.extend({
+    format: Uint16LE,
+    channels: Uint16LE,
+    sampleRate: Uint32LE,
+    bytesPerSec: Uint32LE,
+    blockAlignment: Uint16LE,
+    bitsPerSample: Uint16LE
+}) {}
+
+Packet.initConstructor(WAVEFMTChunkBody);
+
+export {WAVEFMTChunkBody};

--- a/src/playground/field-object.js
+++ b/src/playground/field-object.js
@@ -1,0 +1,44 @@
+import {FieldObject} from '../squeak/field-object';
+
+import {ObjectRenderer} from './object';
+
+const allPropertyDescriptors = prototype => {
+    if (prototype === null) return {};
+    return Object.assign(
+        allPropertyDescriptors(Object.getPrototypeOf(prototype)),
+        Object.getOwnPropertyDescriptors(prototype)
+    );
+};
+
+class FieldObjectRenderer {
+    static check (data) {
+        return data instanceof FieldObject;
+    }
+
+    render (data, view) {
+        new ObjectRenderer().render(
+            Object.assign(() => (
+                Object.entries(
+                    allPropertyDescriptors(Object.getPrototypeOf(data))
+                )
+                    .filter(([, desc]) => desc.get)
+                    .reduce((carry, [key]) => {
+                        Object.defineProperty(carry, key, {
+                            enumerable: true,
+                            get () {
+                                return data[key];
+                            }
+                        });
+                        return carry;
+                    }, {})
+            ), {
+                toString () {
+                    return data.toString();
+                }
+            }),
+            view
+        );
+    }
+}
+
+export {FieldObjectRenderer};

--- a/src/playground/field-object.js
+++ b/src/playground/field-object.js
@@ -1,3 +1,6 @@
+import {PNGFile} from '../coders/png-file';
+import {WAVFile} from '../coders/wav-file';
+
 import {FieldObject} from '../squeak/field-object';
 
 import {ObjectRenderer} from './object';
@@ -15,9 +18,42 @@ class FieldObjectRenderer {
         return data instanceof FieldObject;
     }
 
+    addOptionalPreview (obj) {
+        if (obj.decoded) {
+            let mime;
+            let tag;
+            let encoded;
+            if (obj.extension === 'uncompressed') {
+                mime = 'image/png';
+                tag = new Image();
+                encoded = new Uint8Array(PNGFile.encode(
+                    obj.width,
+                    obj.height,
+                    obj.decoded
+                ));
+            } else if (obj.extension === 'jpg') {
+                mime = 'image/jpg';
+                tag = new Image();
+                encoded = obj.decoded;
+            } else if (obj.extension === 'pcm') {
+                mime = 'audio/wav';
+                tag = new Audio();
+                tag.controls = true;
+                encoded = new Uint8Array(WAVFile.encode(obj.decoded, {
+                    sampleRate: obj.rate && obj.rate.value
+                }));
+            }
+
+            tag.src = URL.createObjectURL(new Blob([encoded.buffer], {type: mime}));
+
+            obj.preview = tag;
+        }
+        return obj;
+    }
+
     render (data, view) {
         new ObjectRenderer().render(
-            Object.assign(() => (
+            Object.assign(() => this.addOptionalPreview(
                 Object.entries(
                     allPropertyDescriptors(Object.getPrototypeOf(data))
                 )

--- a/src/playground/index.js
+++ b/src/playground/index.js
@@ -2,12 +2,14 @@ import {SB1File} from '../..';
 import {SB1View} from './view';
 
 import {ArrayRenderer} from './array';
+import {FieldObjectRenderer} from './field-object';
 import {FieldRenderer} from './field';
 import {JSPrimitiveRenderer} from './js-primitive';
 import {ObjectRenderer} from './object';
 import {ViewableRenderer} from './viewable';
 
 SB1View.register(ArrayRenderer);
+SB1View.register(FieldObjectRenderer);
 SB1View.register(FieldRenderer);
 SB1View.register(JSPrimitiveRenderer);
 SB1View.register(ObjectRenderer);
@@ -24,7 +26,13 @@ const readFile = f => {
         last = [
             new SB1View(sb1, 'file').element,
             new SB1View(Array.from(sb1.infoRaw()), 'raw - info').element,
-            new SB1View(Array.from(sb1.dataRaw()), 'raw - data').element
+            new SB1View(Array.from(sb1.dataRaw()), 'raw - data').element,
+            new SB1View(Array.from(sb1.infoTable()), 'table - info').element,
+            new SB1View(Array.from(sb1.dataTable()), 'table - data').element,
+            new SB1View(sb1.info(), 'info').element,
+            new SB1View(sb1.data(), 'data').element,
+            new SB1View(sb1.images(), 'images').element,
+            new SB1View(sb1.sounds(), 'sounds').element
         ];
         last.forEach(document.body.appendChild, document.body);
     };

--- a/src/playground/index.js
+++ b/src/playground/index.js
@@ -15,6 +15,14 @@ SB1View.register(JSPrimitiveRenderer);
 SB1View.register(ObjectRenderer);
 SB1View.register(ViewableRenderer);
 
+const createDownload = (name, mime, content) => {
+    const anchor = document.createElement('a');
+    anchor.download = name;
+    anchor.href = URL.createObjectURL(new Blob([content], {type: mime}));
+    anchor.innerText = name;
+    return anchor;
+};
+
 let last = null;
 const readFile = f => {
     const reader = new FileReader();
@@ -32,7 +40,9 @@ const readFile = f => {
             new SB1View(sb1.info(), 'info').element,
             new SB1View(sb1.data(), 'data').element,
             new SB1View(sb1.images(), 'images').element,
-            new SB1View(sb1.sounds(), 'sounds').element
+            new SB1View(sb1.sounds(), 'sounds').element,
+            new SB1View(sb1.json, 'json').element,
+            createDownload(`${f.name}.json`, 'application/json', JSON.stringify(sb1.json))
         ];
         last.forEach(document.body.appendChild, document.body);
     };

--- a/src/sb1-file.js
+++ b/src/sb1-file.js
@@ -6,6 +6,9 @@ import {TypeIterator} from './squeak/type-iterator';
 import {ReferenceFixer} from './squeak/reference-fixer';
 import {ImageMediaData, SoundMediaData} from './squeak/types';
 
+import {toSb2FakeZipApi} from './to-sb2/fake-zip';
+import {toSb2Json} from './to-sb2/json-generator';
+
 import {SB1Header, SB1Signature} from './sb1-file-packets';
 
 class SB1File {
@@ -23,6 +26,22 @@ class SB1File {
 
         this.dataHeader = this.stream.readStruct(SB1Header);
         this.dataHeader.validate();
+    }
+
+    get json () {
+        return toSb2Json({
+            info: this.info(),
+            stageData: this.data(),
+            images: this.images(),
+            sounds: this.sounds()
+        });
+    }
+
+    get zip () {
+        return toSb2FakeZipApi({
+            images: this.images(),
+            sounds: this.sounds()
+        });
     }
 
     view () {

--- a/src/squeak/byte-primitives.js
+++ b/src/squeak/byte-primitives.js
@@ -10,38 +10,38 @@ let ReferenceBE;
 if (IS_HOST_LITTLE_ENDIAN) {
     ReferenceBE = new BytePrimitive({
         size: 3,
-        read (uint8, position) {
+        read (uint8a, position) {
             return (
-                (uint8[position + 0] << 16) |
-                (uint8[position + 1] << 8) |
-                uint8[position + 2]
+                (uint8a[position + 0] << 16) |
+                (uint8a[position + 1] << 8) |
+                uint8a[position + 2]
             );
         }
     });
 } else {
     ReferenceBE = new BytePrimitive({
         size: 3,
-        read (uint8, position) {
+        read (uint8a, position) {
             return (
-                (uint8[position + 2] << 16) |
-                (uint8[position + 1] << 8) |
-                uint8[position + 0]
+                (uint8a[position + 2] << 16) |
+                (uint8a[position + 1] << 8) |
+                uint8a[position + 0]
             );
         }
     });
 }
 
 const LargeInt = new BytePrimitive({
-    sizeOf (uint8, position) {
-        const count = Int16BE.read(uint8, position);
+    sizeOf (uint8a, position) {
+        const count = Int16BE.read(uint8a, position);
         return Int16BE.size + count;
     },
-    read (uint8, position) {
+    read (uint8a, position) {
         let num = 0;
         let multiplier = 0;
-        const count = Int16BE.read(uint8, position);
+        const count = Int16BE.read(uint8a, position);
         for (let i = 0; i < count; i++) {
-            num = num + (multiplier * Uint8.read(uint8, position++));
+            num = num + (multiplier * Uint8.read(uint8a, position++));
             multiplier *= 256;
         }
         return num;
@@ -49,64 +49,64 @@ const LargeInt = new BytePrimitive({
 });
 
 const AsciiString = new BytePrimitive({
-    sizeOf (uint8, position) {
-        const count = Uint32BE.read(uint8, position);
+    sizeOf (uint8a, position) {
+        const count = Uint32BE.read(uint8a, position);
         return Uint32BE.size + count;
     },
-    read (uint8, position) {
-        const count = Uint32BE.read(uint8, position);
+    read (uint8a, position) {
+        const count = Uint32BE.read(uint8a, position);
         assert(count < BUFFER_TOO_BIG, 'asciiString too big');
         position += 4;
         let str = '';
         for (let i = 0; i < count; i++) {
-            str += String.fromCharCode(uint8[position++]);
+            str += String.fromCharCode(uint8a[position++]);
         }
         return str;
     }
 });
 
 const Bytes = new BytePrimitive({
-    sizeOf (uint8, position) {
-        return Uint32BE.size + Uint32BE.read(uint8, position);
+    sizeOf (uint8a, position) {
+        return Uint32BE.size + Uint32BE.read(uint8a, position);
     },
-    read (uint8, position) {
-        const count = Uint32BE.read(uint8, position);
+    read (uint8a, position) {
+        const count = Uint32BE.read(uint8a, position);
         assert(count < BUFFER_TOO_BIG, 'bytes too big');
         position += Uint32BE.size;
 
-        assert(count < BUFFER_TOO_BIG, 'uint8 array too big');
-        return new Uint8Array(uint8.buffer, position, count);
+        assert(count < BUFFER_TOO_BIG, 'uint8a array too big');
+        return new Uint8Array(uint8a.buffer, position, count);
     }
 });
 
 const SoundBytes = new BytePrimitive({
-    sizeOf (uint8, position) {
-        return Uint32BE.size + (Uint32BE.read(uint8, position) * 2);
+    sizeOf (uint8a, position) {
+        return Uint32BE.size + (Uint32BE.read(uint8a, position) * 2);
     },
-    read (uint8, position) {
-        const samples = Uint32BE.read(uint8, position);
+    read (uint8a, position) {
+        const samples = Uint32BE.read(uint8a, position);
         assert(samples < BUFFER_TOO_BIG, 'sound too big');
         position += Uint32BE.size;
 
         const count = samples * 2;
-        assert(count < BUFFER_TOO_BIG, 'uint8 array too big');
-        return new Uint8Array(uint8.buffer, position, count);
+        assert(count < BUFFER_TOO_BIG, 'uint8a array too big');
+        return new Uint8Array(uint8a.buffer, position, count);
     }
 });
 
 const Bitmap32BE = new BytePrimitive({
-    sizeOf (uint8, position) {
-        return Uint32BE.size + (Uint32BE.read(uint8, position) * Uint32BE.size);
+    sizeOf (uint8a, position) {
+        return Uint32BE.size + (Uint32BE.read(uint8a, position) * Uint32BE.size);
     },
-    read (uint8, position) {
-        const count = Uint32BE.read(uint8, position);
+    read (uint8a, position) {
+        const count = Uint32BE.read(uint8a, position);
         assert(count < BUFFER_TOO_BIG, 'bitmap too big');
         position += Uint32BE.size;
 
-        assert(count < BUFFER_TOO_BIG, 'uint8 array too big');
+        assert(count < BUFFER_TOO_BIG, 'uint8a array too big');
         const value = new Uint32Array(count);
         for (let i = 0; i < count; i++) {
-            value[i] = Uint32BE.read(uint8, position);
+            value[i] = Uint32BE.read(uint8a, position);
             position += Uint32BE.size;
         }
         return value;
@@ -122,23 +122,23 @@ if (typeof TextDecoder === 'undefined') {
 }
 
 const UTF8 = new BytePrimitive({
-    sizeOf (uint8, position) {
-        return Uint32BE.size + Uint32BE.read(uint8, position);
+    sizeOf (uint8a, position) {
+        return Uint32BE.size + Uint32BE.read(uint8a, position);
     },
-    read (uint8, position) {
-        const count = Uint32BE.read(uint8, position);
+    read (uint8a, position) {
+        const count = Uint32BE.read(uint8a, position);
         assert(count < BUFFER_TOO_BIG, 'utf8 too big');
         position += Uint32BE.size;
 
-        assert(count < BUFFER_TOO_BIG, 'uint8 array too big');
-        return decoder.decode(new Uint8Array(uint8.buffer, position, count));
+        assert(count < BUFFER_TOO_BIG, 'uint8a array too big');
+        return decoder.decode(new Uint8Array(uint8a.buffer, position, count));
     }
 });
 
 const OpaqueColor = new BytePrimitive({
     size: 4,
-    read (uint8, position) {
-        const rgb = Uint32BE.read(uint8, position);
+    read (uint8a, position) {
+        const rgb = Uint32BE.read(uint8a, position);
         const a = 0xff;
         const r = (rgb >> 22) & 0xff;
         const g = (rgb >> 12) & 0xff;
@@ -149,9 +149,9 @@ const OpaqueColor = new BytePrimitive({
 
 const TranslucentColor = new BytePrimitive({
     size: 5,
-    read (uint8, position) {
-        const rgb = Uint32BE.read(uint8, position);
-        const a = Uint8.read(uint8, position);
+    read (uint8a, position) {
+        const rgb = Uint32BE.read(uint8a, position);
+        const a = Uint8.read(uint8a, position);
         const r = (rgb >> 22) & 0xff;
         const g = (rgb >> 12) & 0xff;
         const b = (rgb >> 2) & 0xff;

--- a/src/squeak/field-iterator.js
+++ b/src/squeak/field-iterator.js
@@ -61,12 +61,13 @@ const CONSUMER_PROTOS = {
     [TYPES.OBJECT_REF]: {type: Reference, read: ReferenceBE}
 };
 
-const CONSUMERS = new Array(256).fill(null);
-for (const index of Object.values(TYPES)) {
-    if (CONSUMER_PROTOS[index]) {
-        CONSUMERS[index] = new Consumer(CONSUMER_PROTOS[index]);
+const CONSUMERS = Array.from(
+    {length: 256},
+    (_, i) => {
+        if (CONSUMER_PROTOS[i]) return new Consumer(CONSUMER_PROTOS[i]);
+        return null;
     }
-}
+);
 
 const builtinConsumer = new Consumer({
     type: BuiltinObjectHeader,
@@ -84,7 +85,7 @@ class FieldIterator {
     }
 
     next () {
-        if (this.stream.position >= this.stream.uint8.length) {
+        if (this.stream.position >= this.stream.uint8a.length) {
             return {
                 value: null,
                 done: true

--- a/src/squeak/field-object.js
+++ b/src/squeak/field-object.js
@@ -1,0 +1,61 @@
+import {TYPE_NAMES} from './ids';
+
+const toTitleCase = str => (
+    str.toLowerCase().replace(/_(\w)/g, ([, letter]) => letter.toUpperCase())
+);
+
+class FieldObject {
+    constructor ({classId, version, fields}) {
+        this.classId = classId;
+        this.version = version;
+        this.fields = fields;
+    }
+
+    string (field) {
+        return String(this.fields[field]);
+    }
+
+    number (field) {
+        return +this.fields[field];
+    }
+
+    boolean (field) {
+        return !!this.fields[field];
+    }
+
+    toString () {
+        if (this.constructor === FieldObject) {
+            return `${this.constructor.name} ${this.classId} ${TYPE_NAMES[this.classId]}`;
+        }
+        return this.constructor.name;
+    }
+
+    static define (FIELDS, Super = FieldObject) {
+        class Base extends Super {
+            get FIELDS () {
+                return FIELDS;
+            }
+
+            get RAW_FIELDS () {
+                return this.fields;
+            }
+
+            static get FIELDS () {
+                return FIELDS;
+            }
+        }
+
+        Object.keys(FIELDS).forEach(key => {
+            const index = FIELDS[key];
+            Object.defineProperty(Base.prototype, toTitleCase(key), {
+                get () {
+                    return this.fields[index];
+                }
+            });
+        });
+
+        return Base;
+    }
+}
+
+export {FieldObject};

--- a/src/squeak/reference-fixer.js
+++ b/src/squeak/reference-fixer.js
@@ -1,0 +1,39 @@
+import {Reference} from './fields';
+
+class ReferenceFixer {
+    constructor (table) {
+        this.table = Array.from(table);
+        this.fixed = this.fix(this.table);
+    }
+
+    fix () {
+        const fixed = [];
+
+        for (let i = 0; i < this.table.length; i++) {
+            this.fixItem(this.table[i]);
+            fixed.push(this.table[i]);
+        }
+
+        return fixed;
+    }
+
+    fixItem (item) {
+        if (typeof item.fields !== 'undefined') {
+            item = item.fields;
+        }
+        if (Array.isArray(item)) {
+            for (let i = 0; i < item.length; i++) {
+                item[i] = this.deref(item[i]);
+            }
+        }
+    }
+
+    deref (ref) {
+        if (ref instanceof Reference) {
+            return this.table[ref.index - 1];
+        }
+        return ref;
+    }
+}
+
+export {ReferenceFixer};

--- a/src/squeak/type-iterator.js
+++ b/src/squeak/type-iterator.js
@@ -1,0 +1,53 @@
+import {FieldObjectHeader, Header} from './fields';
+import {FieldObject} from './field-object';
+import {FIELD_OBJECT_CONTRUCTORS} from './types';
+
+class TypeIterator {
+    constructor (valueIterator) {
+        this.valueIterator = valueIterator;
+    }
+
+    [Symbol.iterator] () {
+        return this;
+    }
+
+    next () {
+        const nextHeader = this.valueIterator.next();
+        if (nextHeader.done) {
+            return nextHeader;
+        }
+
+        const header = nextHeader.value;
+        const {classId} = header;
+
+        let value = header;
+
+        if (header instanceof Header) {
+            value = [];
+
+            for (let i = 0; i < header.size; i++) {
+                value.push(this.next().value);
+            }
+        }
+
+        if (
+            FIELD_OBJECT_CONTRUCTORS[classId] !== null ||
+            header instanceof FieldObjectHeader
+        ) {
+            const constructor = FIELD_OBJECT_CONTRUCTORS[header.classId] || FieldObject;
+
+            value = new constructor({
+                classId: header.classId,
+                version: header.version,
+                fields: value
+            });
+        }
+
+        return {
+            value,
+            done: false
+        };
+    }
+}
+
+export {TypeIterator};

--- a/src/squeak/types.js
+++ b/src/squeak/types.js
@@ -1,0 +1,421 @@
+import {CRC32} from '../coders/crc32';
+
+import {FieldObject} from './field-object';
+import {value as valueOf} from './fields';
+import {TYPES} from './ids';
+
+class PointData extends FieldObject.define({
+    X: 0,
+    Y: 1
+}) {}
+
+export {PointData};
+
+class RectangleData extends FieldObject.define({
+    X: 0,
+    Y: 1,
+    X2: 2,
+    Y2: 3
+}) {
+    get width () {
+        return this.x2 - this.x;
+    }
+
+    get height () {
+        return this.y2 - this.y;
+    }
+}
+
+export {RectangleData};
+
+const _bgra2rgbaInPlace = uint8a => {
+    for (let i = 0; i < uint8a.length; i += 4) {
+        const r = uint8a[i + 2];
+        const b = uint8a[i + 0];
+        uint8a[i + 2] = b;
+        uint8a[i + 0] = r;
+    }
+    return uint8a;
+};
+
+class ImageData extends FieldObject.define({
+    WIDTH: 0,
+    HEIGHT: 1,
+    DEPTH: 2,
+    SOMETHING: 3,
+    BYTES: 4,
+    COLORMAP: 5
+}) {
+    get decoded () {
+        throw new Error('Not implemented');
+    }
+
+    get extension () {
+        return 'uncompressed';
+    }
+}
+
+export {ImageData};
+
+class StageData extends FieldObject.define({
+    STAGE_CONTENTS: 2,
+    OBJ_NAME: 6,
+    VARS: 7,
+    BLOCKS_BIN: 8,
+    IS_CLONE: 9,
+    MEDIA: 10,
+    CURRENT_COSTUME: 11,
+    ZOOM: 12,
+    H_PAN: 13,
+    V_PAN: 14,
+    OBSOLETE_SAVED_STATE: 15,
+    SPRITE_ORDER_IN_LIBRARY: 16,
+    VOLUME: 17,
+    TEMPO_BPM: 18,
+    SCENE_STATES: 19,
+    LISTS: 20
+}) {
+    get spriteOrderInLibrary () {
+        return this.fields[this.FIELDS.SPRITE_ORDER_IN_LIBRARY] || null;
+    }
+
+    get tempoBPM () {
+        return this.fields[this.FIELDS.TEMPO_BPM] || 0;
+    }
+
+    get lists () {
+        return this.fields[this.FIELDS.LISTS] || [];
+    }
+}
+
+export {StageData};
+
+class SpriteData extends FieldObject.define({
+    BOX: 0,
+    PARENT: 1,
+    COLOR: 3,
+    VISIBLE: 4,
+    OBJ_NAME: 6,
+    VARS: 7,
+    BLOCKS_BIN: 8,
+    IS_CLONE: 9,
+    MEDIA: 10,
+    CURRENT_COSTUME: 11,
+    VISIBILITY: 12,
+    SCALE_POINT: 13,
+    ROTATION_DEGREES: 14,
+    ROTATION_STYLE: 15,
+    VOLUME: 16,
+    TEMPO_BPM: 17,
+    DRAGGABLE: 18,
+    SCENE_STATES: 19,
+    LISTS: 20
+}) {
+    get scratchX () {
+        return this.box.x + this.currentCostume.rotationCenter.x - 240;
+    }
+
+    get scratchY () {
+        return 180 - (this.box.y + this.currentCostume.rotationCenter.y);
+    }
+
+    get visible () {
+        return (this.fields[this.FIELDS.VISIBLE] & 1) === 0;
+    }
+
+    get tempoBPM () {
+        return this.fields[this.FIELDS.TEMPO_BPM] || 0;
+    }
+
+    get lists () {
+        return this.fields[this.FIELDS.LISTS] || [];
+    }
+}
+
+export {SpriteData};
+
+class TextDetailsData extends FieldObject.define({
+    RECTANGLE: 0,
+    FONT: 8,
+    COLOR: 9,
+    LINES: 11
+}) {}
+
+export {TextDetailsData};
+
+class ImageMediaData extends FieldObject.define({
+    COSTUME_NAME: 0,
+    BITMAP: 1,
+    ROTATION_CENTER: 2,
+    TEXT_DETAILS: 3,
+    BASE_LAYER_DATA: 4,
+    OLD_COMPOSITE: 5
+}) {
+    get image () {
+        if (this.oldComposite instanceof ImageData) {
+            return this.oldComposite;
+        }
+        if (this.baseLayerData.value) {
+            return null;
+        }
+        return this.bitmap;
+    }
+
+    get width () {
+        if (this.image === null) {
+            return -1;
+        }
+        return this.image.width;
+    }
+
+    get height () {
+        if (this.image === null) {
+            return -1;
+        }
+        return this.image.height;
+    }
+
+    get rawBytes () {
+        if (this.image === null) {
+            return this.baseLayerData.value.slice();
+        }
+        return this.image.bytes.value;
+    }
+
+    get decoded () {
+        if (this.image === null) {
+            return this.baseLayerData.value.slice();
+        }
+        return this.image.decoded;
+    }
+
+    get crc () {
+        if (!this._crc) {
+            const crc = new CRC32()
+                .update(new Uint8Array(new Uint32Array([this.bitmap.width]).buffer))
+                .update(new Uint8Array(new Uint32Array([this.bitmap.height]).buffer))
+                .update(new Uint8Array(new Uint32Array([this.bitmap.depth]).buffer))
+                .update(this.rawBytes);
+            this._crc = crc.digest;
+        }
+        return this._crc;
+    }
+
+    get extension () {
+        if (this.oldComposite instanceof ImageData) return 'uncompressed';
+        if (this.baseLayerData.value) return 'jpg';
+        return 'uncompressed';
+    }
+
+    toString () {
+        return `ImageMediaData "${this.costumeName}"`;
+    }
+}
+
+export {ImageMediaData};
+
+class UncompressedData extends FieldObject.define({
+    DATA: 3,
+    RATE: 4
+}) {}
+
+export {UncompressedData};
+
+class SoundMediaData extends FieldObject.define({
+    NAME: 0,
+    UNCOMPRESSED: 1,
+    RATE: 4,
+    BITS_PER_SAMPLE: 5,
+    DATA: 6
+}) {
+    get rate () {
+        if (this.uncompressed.data.value.length !== 0) {
+            return this.uncompressed.rate;
+        }
+        return this.fields[this.FIELDS.RATE];
+    }
+
+    get rawBytes () {
+        if (this.data && this.data.value) {
+            return this.data.value;
+        }
+        return this.uncompressed.data.value;
+    }
+
+    get decoded () {
+        throw new Error('Not implemented');
+    }
+
+    get crc () {
+        if (!this._crc) {
+            this._crc = new CRC32()
+                .update(new Uint32Array([this.rate]))
+                .update(this.rawBytes)
+                .digest;
+        }
+        return this._crc;
+    }
+
+    get sampleCount () {
+        throw new Error('Not implemented');
+    }
+
+    get extension () {
+        return 'pcm';
+    }
+
+    toString () {
+        return `SoundMediaData "${this.name}"`;
+    }
+}
+
+export {SoundMediaData};
+
+class ListWatcherData extends FieldObject.define({
+    BOX: 0,
+    HIDDEN_WHEN_NULL: 1,
+    LIST_NAME: 8,
+    CONTENTS: 9,
+    TARGET: 10
+}) {
+    get x () {
+        if (valueOf(this.hiddenWhenNull) === null) return 5;
+        return this.box.x + 1;
+    }
+
+    get y () {
+        if (valueOf(this.hiddenWhenNull) === null) return 5;
+        return this.box.y + 1;
+    }
+
+    get width () {
+        return this.box.width - 2;
+    }
+
+    get height () {
+        return this.box.height - 2;
+    }
+}
+
+export {ListWatcherData};
+
+class AlignmentData extends FieldObject.define({
+    BOX: 0,
+    PARENT: 1,
+    FRAMES: 2,
+    COLOR: 3,
+    DIRECTION: 8,
+    ALIGNMENT: 9
+}) {}
+
+export {AlignmentData};
+
+class MorphData extends FieldObject.define({
+    BOX: 0,
+    PARENT: 1,
+    COLOR: 3
+}) {}
+
+export {MorphData};
+
+class StaticStringData extends FieldObject.define({
+    BOX: 0,
+    COLOR: 3,
+    VALUE: 8
+}) {}
+
+export {StaticStringData};
+
+class UpdatingStringData extends FieldObject.define({
+    BOX: 0,
+    READOUT_FRAME: 1,
+    COLOR: 3,
+    FONT: 6,
+    VALUE: 8,
+    TARGET: 10,
+    CMD: 11,
+    PARAM: 13
+}) {}
+
+export {UpdatingStringData};
+
+class WatcherReadoutFrameData extends FieldObject.define({
+    BOX: 0
+}) {}
+
+export {WatcherReadoutFrameData};
+
+const WATCHER_MODES = {
+    NORMAL: 1,
+    LARGE: 2,
+    SLIDER: 3,
+    TEXT: 4
+};
+
+export {WATCHER_MODES};
+
+class WatcherData extends FieldObject.define({
+    BOX: 0,
+    TARGET: 1,
+    SHAPE: 2,
+    READOUT: 14,
+    READOUT_FRAME: 15,
+    SLIDER: 16,
+    ALIGNMENT: 17,
+    SLIDER_MIN: 20,
+    SLIDER_MAX: 21
+}) {
+    get x () {
+        return this.box.x;
+    }
+
+    get y () {
+        return this.box.y;
+    }
+
+    get mode () {
+        if (valueOf(this.slider) === null) {
+            if (this.readoutFrame.box.height <= 14) {
+                return WATCHER_MODES.NORMAL;
+            }
+            return WATCHER_MODES.LARGE;
+        }
+        return WATCHER_MODES.SLIDER;
+    }
+
+    get isDiscrete () {
+        return (
+            Math.floor(this.sliderMin) === this.sliderMin &&
+            Math.floor(this.sliderMax) === this.sliderMax &&
+            Math.floor(this.readout.value) === this.readout.value
+        );
+    }
+}
+
+export {WatcherData};
+
+const FIELD_OBJECT_CONTRUCTOR_PROTOS = {
+    [TYPES.POINT]: PointData,
+    [TYPES.RECTANGLE]: RectangleData,
+    [TYPES.FORM]: ImageData,
+    [TYPES.SQUEAK]: ImageData,
+    [TYPES.SAMPLED_SOUND]: UncompressedData,
+    [TYPES.SPRITE]: SpriteData,
+    [TYPES.STAGE]: StageData,
+    [TYPES.IMAGE_MEDIA]: ImageMediaData,
+    [TYPES.SOUND_MEDIA]: SoundMediaData,
+    [TYPES.ALIGNMENT]: AlignmentData,
+    [TYPES.MORPH]: MorphData,
+    [TYPES.WATCHER_READOUT_FRAME]: WatcherReadoutFrameData,
+    [TYPES.STATIC_STRING]: StaticStringData,
+    [TYPES.UPDATING_STRING]: UpdatingStringData,
+    [TYPES.WATCHER]: WatcherData,
+    [TYPES.LIST_WATCHER]: ListWatcherData
+};
+
+const FIELD_OBJECT_CONTRUCTORS = Array.from(
+    {length: 256},
+    (_, i) => (FIELD_OBJECT_CONTRUCTOR_PROTOS[i] || null)
+);
+
+export {FIELD_OBJECT_CONTRUCTORS};

--- a/src/to-sb2/fake-zip.js
+++ b/src/to-sb2/fake-zip.js
@@ -1,0 +1,78 @@
+import {assert} from '../util/assert';
+
+import {PNGFile} from '../coders/png-file';
+import {WAVFile} from '../coders/wav-file';
+
+class FakeZipFile {
+    constructor (file) {
+        this.file = file;
+    }
+
+    async (outputType) {
+        assert(outputType === 'uint8array', 'SB1FakeZipFile only supports uint8array');
+
+        return Promise.resolve(this.file.bytes);
+    }
+}
+
+export {FakeZipFile};
+
+class FakeZip {
+    constructor (files) {
+        this.files = files;
+    }
+
+    file (file) {
+        if (file in this.files) {
+            return new FakeZipFile(this.files[file]);
+        }
+    }
+}
+
+export {FakeZip};
+
+const toSb2ImageExtension = imageMedia => {
+    if (imageMedia.extension === 'uncompressed') {
+        return 'png';
+    }
+    return 'jpg';
+};
+
+const toSb2ImageMedia = imageMedia => {
+    if (imageMedia.extension === 'uncompressed') {
+        return new Uint8Array(PNGFile.encode(
+            imageMedia.width,
+            imageMedia.height,
+            imageMedia.decoded
+        ));
+    }
+    return imageMedia.decoded;
+};
+
+const toSb2SoundMedia = soundMedia => (
+    new Uint8Array(WAVFile.encode(soundMedia.decoded, {
+        sampleRate: soundMedia.rate && soundMedia.rate.value
+    }))
+);
+
+const toSb2FakeZipApi = ({images, sounds}) => {
+    const files = {};
+
+    let index = 0;
+    for (const image of images) {
+        files[`${index++}.${toSb2ImageExtension(image)}`] = {
+            bytes: toSb2ImageMedia(image)
+        };
+    }
+
+    index = 0;
+    for (const sound of sounds) {
+        files[`${index++}.wav`] = {
+            bytes: toSb2SoundMedia(sound)
+        };
+    }
+
+    return new FakeZip(files);
+};
+
+export {toSb2FakeZipApi};

--- a/src/to-sb2/json-generator.js
+++ b/src/to-sb2/json-generator.js
@@ -1,0 +1,225 @@
+/* eslint no-use-before-define:1 */
+
+import {ImageMediaData, SoundMediaData, SpriteData} from '../squeak/types';
+
+const sb1SpecMap = {
+    // https://github.com/LLK/scratch-flash/blob/cb5f42f039ef633710faf9c63b69e8368b280372/src/blocks/BlockIO.as#L197-L199
+    'getParam': ([a, b, c, d]) => [a, b, c, d || 'r'],
+    // https://github.com/LLK/scratch-flash/blob/cb5f42f039ef633710faf9c63b69e8368b280372/src/blocks/BlockIO.as#L200-L212
+    'changeVariable': block => [block[2], block[1], block[3]],
+    // https://github.com/LLK/scratch-flash/blob/cb5f42f039ef633710faf9c63b69e8368b280372/src/blocks/BlockIO.as#L213-L219
+    'EventHatMorph': block => {
+        if (String(block[1]) === 'Scratch-StartClicked') {
+            return ['whenGreenFlag'];
+        }
+        return ['whenIReceive', block[1]];
+    },
+    // https://github.com/LLK/scratch-flash/blob/cb5f42f039ef633710faf9c63b69e8368b280372/src/blocks/BlockIO.as#L220-L222
+    'MouseClickEventHatMorph': () => ['whenClicked'],
+    // https://github.com/LLK/scratch-flash/blob/cb5f42f039ef633710faf9c63b69e8368b280372/src/blocks/BlockIO.as#L223-L226
+    'KeyEventHatMorph': block => ['whenKeyPressed', block[1]],
+    // https://github.com/LLK/scratch-flash/blob/cb5f42f039ef633710faf9c63b69e8368b280372/src/blocks/BlockIO.as#L227-L235
+    'stopScripts': block => {
+        if (String(block[1]) === 'other scripts') {
+            return [block[0], 'other scripts in sprite'];
+        }
+        return block;
+    },
+    // https://github.com/LLK/scratch-flash/blob/cb5f42f039ef633710faf9c63b69e8368b280372/src/blocks/BlockIO.as#L249-L253
+    'abs': block => ['computeFunction:of:', 'abs', block[1]],
+    // https://github.com/LLK/scratch-flash/blob/cb5f42f039ef633710faf9c63b69e8368b280372/src/blocks/BlockIO.as#L254-L258
+    'sqrt': block => ['computeFunction:of:', 'sqrt', block[1]],
+    // https://github.com/LLK/scratch-flash/blob/cb5f42f039ef633710faf9c63b69e8368b280372/src/blocks/BlockIO.as#L137
+    '\\\\': block => ['%', ...block.slice(1)],
+    // https://github.com/LLK/scratch-flash/blob/cb5f42f039ef633710faf9c63b69e8368b280372/src/blocks/BlockIO.as#L259-L262
+    'doReturn': () => ['stopScripts', 'this script'],
+    // https://github.com/LLK/scratch-flash/blob/cb5f42f039ef633710faf9c63b69e8368b280372/src/blocks/BlockIO.as#L263-L266
+    'stopAll': () => ['stopScripts', 'all'],
+    // https://github.com/LLK/scratch-flash/blob/cb5f42f039ef633710faf9c63b69e8368b280372/src/blocks/BlockIO.as#L267-L270
+    'showBackground:': block => ['startScene', block[1]],
+    // https://github.com/LLK/scratch-flash/blob/cb5f42f039ef633710faf9c63b69e8368b280372/src/blocks/BlockIO.as#L271-L273
+    'nextBackground': () => ['nextScene'],
+    // https://github.com/LLK/scratch-flash/blob/cb5f42f039ef633710faf9c63b69e8368b280372/src/blocks/BlockIO.as#L274-L282
+    'doForeverIf': block => ['doForever', [['doIf', block[1], block[2]]]]
+};
+
+const valueOf = obj => {
+    if (typeof obj === 'object' && obj) return obj.valueOf();
+    return obj;
+};
+
+const toSb2Json = root => {
+    const {info, stageData, images, sounds} = root;
+
+    const pairs = array => {
+        const _pairs = [];
+        for (let i = 0; i < array.length; i += 2) {
+            _pairs.push([array[i], array[i + 1]]);
+        }
+        return _pairs;
+    };
+
+    const toSb2JsonVariable = ([name, value]) => ({
+        name,
+        value,
+        isPersistent: false
+    });
+
+    const toSb2JsonList = ([, {
+        listName, contents, x, y, width, height, hiddenWhenNull
+    }]) => ({
+        listName: listName,
+        contents: contents,
+        isPersistent: false,
+        x: x,
+        y: y,
+        width: width,
+        height: height,
+        visible: valueOf(hiddenWhenNull) !== null
+    });
+
+    // TODO: Implement toSb2JsonWatcher
+    // const toSb2JsonWatcher = watcher => {
+    //
+    // };
+
+    // TODO: Implement toSb2JsonListWatcher
+    // const toSb2JsonListWatcher = listWatcher => {
+    //
+    // };
+
+    const toSb2JsonSound = soundMediaData => {
+        const soundID = sounds.findIndex(sound => sound.crc === soundMediaData.crc);
+        return {
+            soundName: soundMediaData.name,
+            soundID,
+            // TODO: Produce a proper MD5.
+            md5: `${soundID}.wav`,
+            sampleCount: soundMediaData.sampleCount,
+            rate: soundMediaData.rate,
+            format: ''
+        };
+    };
+
+    const toSb2ImageExtension = imageMedia => {
+        if (imageMedia.extension === 'uncompressed') {
+            return 'png';
+        }
+        return 'jpg';
+    };
+
+    const toSb2JsonCostume = imageMediaData => {
+        const baseLayerID = images.findIndex(image => image.crc === imageMediaData.crc);
+        return {
+            costumeName: imageMediaData.costumeName,
+            baseLayerID,
+            // TODO: Produce a proper MD5.
+            baseLayerMD5: `${baseLayerID}.${toSb2ImageExtension(imageMediaData)}`,
+            bitmapResolution: 1,
+            rotationCenterX: imageMediaData.rotationCenter.x,
+            rotationCenterY: imageMediaData.rotationCenter.y
+        };
+    };
+
+    const toSb2JsonBlock = blockData => {
+        let output = blockData.map(toSb2JsonBlockArg);
+        const spec = sb1SpecMap[output[0]];
+        if (spec) {
+            output = spec(output);
+        }
+        return output;
+    };
+
+    const toSb2JsonStack = stackData => stackData.map(toSb2JsonBlock);
+
+    const toSb2JsonBlockArg = argData => {
+        if (argData instanceof SpriteData) {
+            return argData.objName;
+        } else if (Array.isArray(argData)) {
+            if (argData.length === 0 || Array.isArray(argData[0])) {
+                return toSb2JsonStack(argData);
+            }
+            return toSb2JsonBlock(argData);
+        }
+        return argData;
+    };
+
+    const toSb2JsonScript = scriptData => (
+        [
+            scriptData[0].x,
+            scriptData[0].y,
+            toSb2JsonStack(scriptData[1])
+        ]
+    );
+
+    const toSb2JsonSprite = spriteData => {
+        const rawCostumes = spriteData.media
+            .filter(data => data instanceof ImageMediaData);
+        const rawSounds = spriteData.media
+            .filter(data => data instanceof SoundMediaData);
+        return {
+            objName: spriteData.objName,
+            variables: pairs(spriteData.vars).map(toSb2JsonVariable),
+            lists: pairs(spriteData.lists).map(toSb2JsonList),
+            scripts: spriteData.blocksBin.map(toSb2JsonScript),
+            costumes: rawCostumes
+                .map(toSb2JsonCostume),
+            currentCostumeIndex: rawCostumes.findIndex(image => image.crc === spriteData.currentCostume.crc),
+            sounds: rawSounds.map(toSb2JsonSound),
+            scratchX: spriteData.scratchX,
+            scratchY: spriteData.scratchY,
+            scale: spriteData.scalePoint.x,
+            direction: (Math.round(spriteData.rotationDegrees * 1e6) / 1e6) - 270,
+            rotationStyle: spriteData.rotationStyle,
+            isDraggable: spriteData.draggable,
+            indexInLibrary: stageData.spriteOrderInLibrary.indexOf(spriteData),
+            visible: spriteData.visible,
+            spriteInfo: {}
+        };
+    };
+
+    const toSb2JsonChild = child => {
+        if (child instanceof SpriteData) {
+            return toSb2JsonSprite(child);
+        }
+        return null;
+    };
+
+    const toSb2JsonStage = _stageData => {
+        const rawCostumes = _stageData.media
+            .filter(data => data instanceof ImageMediaData);
+        const rawSounds = _stageData.media
+            .filter(data => data instanceof SoundMediaData);
+        return {
+            objName: _stageData.objName,
+            variables: pairs(_stageData.vars).map(toSb2JsonVariable),
+            lists: pairs(_stageData.lists).map(toSb2JsonList),
+            scripts: _stageData.blocksBin.map(toSb2JsonScript),
+            costumes: rawCostumes
+                .map(toSb2JsonCostume),
+            currentCostumeIndex: rawCostumes.findIndex(image => image.crc === _stageData.currentCostume.crc),
+            sounds: rawSounds.map(toSb2JsonSound),
+            // TODO: Where does this come from? Is it always the same for SB1?
+            penLayerMD5: '5c81a336fab8be57adc039a8a2b33ca9.png',
+            penLayerID: 0,
+            tempoBPM: _stageData.tempoBPM,
+            videoAlpha: 0.5,
+            children: _stageData.stageContents.map(toSb2JsonChild).filter(Boolean)
+        };
+    };
+
+    const toSb2JsonInfo = _info => {
+        const obj = {};
+        for (let i = 0; i < _info.length; i += 2) {
+            if (String(_info[i]) === 'thumbnail') continue;
+            obj[String(_info[i])] = String(_info[i + 1]);
+        }
+        return obj;
+    };
+
+    return JSON.parse(JSON.stringify(Object.assign(toSb2JsonStage(stageData), {
+        info: toSb2JsonInfo(info)
+    })));
+};
+
+export {toSb2Json};


### PR DESCRIPTION
Live playground: https://mzgoddard.github.io/scratch-sb1-converter/to-sb2/
Live GUI playground: https://mzgoddard.github.io/scratch-gui/sb1-converter--to-sb2/#185346

- Add Generator from decoded FieldObject data objects to SB2 JSON
- Convert ImageData, ImageMediaData, and SoundMediaData to PNGs and WAVs
- Provide the assets in a FakeZip that mirrors zip decoder used in scratch-vm

### SB2 JSON Generator

The SB2 JSON format is similar in decoded in memory to the SB format. Some member names change, some block opcode names change, and some x, y positions and other integers translate into different coordinate plane. The produced tree from FieldIterator and TypeIterator is turned into JSON walking the tree with a set of functions.

The generator uses a `sb1SpecMap` like scratch-vm for sb2. Instead of specifying the arguments and fields it uses small functions to translate the sb1 block tree to an sb2 block tree following code from scratch-flash.

The last step is passing the output through `JSON.parse(JSON.stringify(...))` to collapse any Value objects to their raw value.

### FakeZip

The FakeZip tries to present the PNG and WAV data content with an API that matches the zip decoder used in scratch-vm. This might be replaced with a zip encoder that creates a proper zip with the assets and the generated json, that the scratch-vm would then re-decode. (Of that zip encoding may be useful to use in the playground tool to translate `.sb` to `.sb2` and test loading the `.sb` and `.sb2` versions in the GUI.)

```js
class FakeZip {
    file (filename) {
        return new FakeZipFile(...);
    }
}

class FakeZipFile {
    async (outputType) {
        return ...;
    }
}
```

### TODO

- [x] Live playground url
- [x] Live GUI playground url
<del>- [ ] toSb2JsonWatcher implementation</del>
<del>- [ ] toSb2JsonListWatcher implementation</del>
<del>- [ ] Documentation!</del>
<del>- [ ] Tests!</del>
