### PR TITLE
fix: set playground/main.js as main entry point

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,8 +7,8 @@
 /.travis.yml
 /test
 
-# Build created files
-/playground
+# Exclude build created docs, but allow other playground/* files
+/playground/docs
 
 # Coverage created files
 /.nyc_output

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "type": "git",
     "url": "https://github.com/LLK/scratch-sb1-converter.git"
   },
-  "main": "index.js",
+  "main": "playground/main.js",
+  "browser": "index.js",
   "scripts": {
     "build": "npm run docs && webpack --progress --colors --bail",
     "commitmsg": "commitlint -e $GIT_PARAMS",
@@ -18,7 +19,7 @@
     "docs": "jsdoc -c .jsdoc.json",
     "lint": "eslint .",
     "prepublish": "in-publish && npm run build || not-in-publish",
-    "start": "webpack-dev-server",
+    "start": "webpack-dev-server --output-library-target=umd2",
     "test:ci:build": "babel --presets @babel/preset-env . --out-dir dist/test-tmp --only src,test,index.js --source-maps",
     "test:ci:unit": "npm run test:ci:build && tap ./dist/test-tmp/test/unit",
     "test:ci:integration": "npm run test:ci:build && tap ./dist/test-tmp/test/integration",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,8 +14,10 @@ module.exports = {
         view: './src/playground/index.js'
     },
     output: {
-        path: path.resolve(__dirname, 'playground')
+        path: path.resolve(__dirname, 'playground'),
+        libraryTarget: 'commonjs2'
     },
+    externals: ['text-encoding'],
     module: {
         rules: [{
             test: /\.js$/,


### PR DESCRIPTION
### Resolves

Build and deploy to npm a version of this package that can be loaded by node.

### Proposed Changes

- Include playground/*.js in npm deploy
- Exclude playground/docs

### Reason for Changes

`scratch-vm` needs dependencies to be loadable by node for its tests.