### PR TITLE
feat: export AssertionError and ValidationError

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
 export {SB1File} from './sb1-file';
+export {AssertionError, ValidationError} from './util/assert';

--- a/src/sb1-file-packets.js
+++ b/src/sb1-file-packets.js
@@ -27,7 +27,7 @@ class SB1Signature extends Packet.extend({
      * @throws {AssertionError} Throws if it is not valid.
      */
     validate () {
-        assert(
+        assert.validate(
             this.equals({version: 'ScratchV01'}) ||
             this.equals({version: 'ScratchV02'}),
             'Invalid Scratch file signature.'
@@ -45,7 +45,7 @@ class SB1Header extends Packet.extend({
     numObjects: Uint32BE
 }) {
     validate () {
-        assert(
+        assert.validate(
             this.equals({
                 ObjS: 'ObjS',
                 ObjSValue: 1,

--- a/src/util/assert.js
+++ b/src/util/assert.js
@@ -3,11 +3,21 @@
  */
 class AssertionError extends Error {}
 
+/**
+ * A `scratch-sb1-converter` validation error.
+ */
+class ValidationError extends AssertionError {}
+
 const assert = function (test, message) {
     if (!test) throw new AssertionError(message);
 };
 
+assert.validate = function (test, message) {
+    if (!test) throw new ValidationError(message);
+};
+
 export {
+    assert,
     AssertionError,
-    assert
+    ValidationError
 };


### PR DESCRIPTION
### Proposed Changes

- Add ValidationError
- Throw ValidationError in SB1File validation

### Reason for Changes

Add ValidationError to help distinguish between unrecoverable errors
while decoding an `.sb` file and encoding to Scratch 2 data.

Export AssertionError and ValidationError so users of the converter can
know when an error is from validating the Scratch 1 file (as in it
likely is not an Scratch 1 file) or from making sure the Scratch 1 file
data matches expected ranges (like not making memory buffers that are
too big).
