### PR TITLE
ci(semver): change deploy provider to script to run semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
 - node
 cache:
   directories:
-  - ~/.npm
   - node_modules
 install:
   - npm install
@@ -16,7 +15,7 @@ before_deploy:
 - git config --global user.email "$(git log --pretty=format:"%ae" -n1)"
 - git config --global user.name "$(git log --pretty=format:"%an" -n1)"
 deploy:
-- provider: npm
+- provider: script
   on:
     branch: develop
     node: '8'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scratch-sb1-converter",
-  "version": "0.0.0-development",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5388,12 +5388,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
-    },
-    "in-publish": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
       "dev": true
     },
     "indent-string": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scratch-sb1-converter",
-  "version": "0.1.0",
+  "version": "0.0.0-development",
   "description": "Scratch 1 (.sb) to Scratch 2 (.sb2) conversion library for Scratch 3.0",
   "author": "Scratch Foundation",
   "license": "BSD-3-Clause",
@@ -18,7 +18,6 @@
     "deploy": "touch playground/.nojekyll && gh-pages -t -d playground -m \"Build for $(git log --pretty=format:%H -n1)\"",
     "docs": "jsdoc -c .jsdoc.json",
     "lint": "eslint .",
-    "prepublish": "in-publish && npm run build || not-in-publish",
     "start": "webpack-dev-server --output-library-target=umd2",
     "test:ci:build": "babel --presets @babel/preset-env . --out-dir dist/test-tmp --only src,test,index.js --source-maps",
     "test:ci:unit": "npm run test:ci:build && tap ./dist/test-tmp/test/unit",
@@ -28,7 +27,6 @@
     "test:integration": "tap --node-arg=--require --node-arg=@babel/register ./test/integration",
     "test": "npm run lint && npm run docs && npm run test:unit && npm run test:integration",
     "watch": "webpack --progress --colors --watch",
-    "version": "json -f package.json -I -e \"this.repository.sha = '$(git log -n1 --pretty=format:%H)'\"",
     "semantic-release": "semantic-release"
   },
   "dependencies": {
@@ -52,7 +50,6 @@
     "gh-pages": "^1.2.0",
     "html-webpack-plugin": "^3.2.0",
     "husky": "0.14.3",
-    "in-publish": "^2.0.0",
     "jsdoc": "^3.5.5",
     "json": "^9.0.4",
     "semantic-release": "^15.13.1",


### PR DESCRIPTION
- I ran semantic-release-cli setup, which changed the version in the package.json back to 0.0.0-development.

- Fix the deploy provider, because when it was set to npm, I don't think it was running semantic-release