### PR TITLE
ci(semver): configure semantic-release to run from develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
+  },
+  "release": {
+    "branch": "develop"
   }
 }


### PR DESCRIPTION
add release section to package.json so that semantic-release can run from develop instead of master
- ran semantic-release locally with dry run option to test this out