### PR TITLE
Remove src/index.js exports maintenance burden

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,2 @@
-const {SB1File} = require('./src');
-
-exports.SB1File = SB1File;
+export {SB1File} from './src/sb1-file';
+export {AssertionError, ValidationError} from './src/util/assert';

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,0 @@
-export {SB1File} from './sb1-file';
-export {AssertionError, ValidationError} from './util/assert';


### PR DESCRIPTION
### Reason for Changes

Remove extra maintenance burden of an extra index.js in the exports chain.
