### PR TITLE
Convert AssertionErrors to ValidationErrors inside validate region

### DIFF
--- a/src/sb1-file-packets.js
+++ b/src/sb1-file-packets.js
@@ -27,11 +27,13 @@ class SB1Signature extends Packet.extend({
      * @throws {AssertionError} Throws if it is not valid.
      */
     validate () {
-        assert.validate(
-            this.equals({version: 'ScratchV01'}) ||
-            this.equals({version: 'ScratchV02'}),
-            'Invalid Scratch file signature.'
-        );
+        assert.validate(() => (
+            assert(
+                this.equals({version: 'ScratchV01'}) ||
+                this.equals({version: 'ScratchV02'}),
+                'Invalid Scratch file signature.'
+            )
+        ));
     }
 }
 
@@ -45,15 +47,17 @@ class SB1Header extends Packet.extend({
     numObjects: Uint32BE
 }) {
     validate () {
-        assert.validate(
-            this.equals({
-                ObjS: 'ObjS',
-                ObjSValue: 1,
-                Stch: 'Stch',
-                StchValue: 1
-            }),
-            'Invalid Scratch file info packet header.'
-        );
+        assert.validate(() => (
+            assert(
+                this.equals({
+                    ObjS: 'ObjS',
+                    ObjSValue: 1,
+                    Stch: 'Stch',
+                    StchValue: 1
+                }),
+                'Invalid Scratch file info packet header.'
+            )
+        ));
     }
 }
 

--- a/src/sb1-file.js
+++ b/src/sb1-file.js
@@ -1,3 +1,5 @@
+import {assert} from './util/assert';
+
 import {ByteStream} from './coders/byte-stream';
 
 import {ByteTakeIterator} from './squeak/byte-take-iterator';

--- a/src/util/assert.js
+++ b/src/util/assert.js
@@ -6,14 +6,30 @@ class AssertionError extends Error {}
 /**
  * A `scratch-sb1-converter` validation error.
  */
-class ValidationError extends AssertionError {}
+class ValidationError extends Error {
+    constructor (assertion) {
+        super(assertion.message);
+        this.assertion = assertion;
+    }
+
+    get stack () {
+        return this.assertion.stack;
+    }
+}
 
 const assert = function (test, message) {
     if (!test) throw new AssertionError(message);
 };
 
-assert.validate = function (test, message) {
-    if (!test) throw new ValidationError(message);
+assert.validate = function (region) {
+    try {
+        return region();
+    } catch (e) {
+        if (e instanceof AssertionError) {
+            throw new ValidationError(e);
+        }
+        throw e;
+    }
 };
 
 export {


### PR DESCRIPTION
### Proposed Changes

When an AssertionError throws in an assert.validate(() => {...}) region, cast/wrap it to a ValidationError.

### Reason for Changes

AssertionErrors thrown by say FixedAsciiString while decoding a value to be validated should be cast to ValidationErrors as during that span of time that is what they are.
