### PR TITLE
fix(json-generator): use real md5s in produced sb2 json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scratch-sb1-converter",
-  "version": "0.1.0",
+  "version": "0.0.0-development",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5934,6 +5934,11 @@
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.4.tgz",
       "integrity": "sha512-PxfGzSs0ztShKrUYPIn5r0MtyAhYcCwmndozzpz8YObbPnD1jFxzlBGbRnX2mIu6Z13xN6+PTu05TQFnZFlzow==",
       "dev": true
+    },
+    "js-md5": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.7.3.tgz",
+      "integrity": "sha512-ZC41vPSTLKGwIRjqDh8DfXoCrdQIyBgspJVPXHBGu4nZlAEvG3nf+jO9avM9RmLiGakg7vz974ms99nEV0tmTQ=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "dependencies": {
     "minilog": "3.1.0",
-    "text-encoding": "^0.6.4"
+    "text-encoding": "^0.6.4",
+    "js-md5": "0.7.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.0",

--- a/src/to-sb2/json-generator.js
+++ b/src/to-sb2/json-generator.js
@@ -1,6 +1,7 @@
 /* eslint no-use-before-define:1 */
 
 import {ImageMediaData, SoundMediaData, SpriteData} from '../squeak/types';
+import md5 from 'js-md5';
 
 const sb1SpecMap = {
     // https://github.com/LLK/scratch-flash/blob/cb5f42f039ef633710faf9c63b69e8368b280372/src/blocks/BlockIO.as#L197-L199
@@ -93,10 +94,7 @@ const toSb2Json = root => {
         return {
             soundName: soundMediaData.name,
             soundID,
-            // TODO: Produce a proper MD5.
-            // Note producing a proper MD5 may not be important since we deliver
-            // the assets through a fake (or possibly in the future) a real zip.
-            md5: `${soundID}.wav`,
+            md5: `${md5(soundMediaData.rawBytes)}.wav`,
             sampleCount: soundMediaData.sampleCount,
             rate: soundMediaData.rate,
             format: ''
@@ -115,10 +113,7 @@ const toSb2Json = root => {
         return {
             costumeName: imageMediaData.costumeName,
             baseLayerID,
-            // TODO: Produce a proper MD5.
-            // Note producing a proper MD5 may not be important since we deliver
-            // the assets through a fake (or possibly in the future) a real zip.
-            baseLayerMD5: `${baseLayerID}.${toSb2ImageExtension(imageMediaData)}`,
+            baseLayerMD5: `${md5(imageMediaData.rawBytes)}.${toSb2ImageExtension(imageMediaData)}`,
             bitmapResolution: 1,
             rotationCenterX: imageMediaData.rotationCenter.x,
             rotationCenterY: imageMediaData.rotationCenter.y


### PR DESCRIPTION
project validation was failing when trying to save a project originally from 1.4 as an sb3 because
the md5s in the produced sb2 file were not of the right format