### PR TITLE
fix: fix sound md5s in generated sb2 json

### DIFF
--- a/src/squeak/types.js
+++ b/src/squeak/types.js
@@ -1,10 +1,13 @@
 import {CRC32} from '../coders/crc32';
 import {SqueakImage} from '../coders/squeak-image';
 import {SqueakSound} from '../coders/squeak-sound';
+import {WAVFile} from '../coders/wav-file';
 
 import {FieldObject} from './field-object';
 import {value as valueOf} from './fields';
 import {TYPES} from './ids';
+
+import md5 from 'js-md5';
 
 /**
  * @extends FieldObject
@@ -340,6 +343,22 @@ class SoundMediaData extends FieldObject.define({
 
     get extension () {
         return 'pcm';
+    }
+
+    get wavEncodedData () {
+        if (!this._wavEncodedData) {
+            this._wavEncodedData = new Uint8Array(WAVFile.encode(this.decoded, {
+                sampleRate: this.rate && this.rate.value
+            }));
+        }
+        return this._wavEncodedData;
+    }
+
+    get md5 () {
+        if (!this._md5) {
+            this._md5 = md5(this.wavEncodedData);
+        }
+        return this._md5;
     }
 
     toString () {

--- a/src/to-sb2/fake-zip.js
+++ b/src/to-sb2/fake-zip.js
@@ -1,7 +1,6 @@
 import {assert} from '../util/assert';
 
 import {PNGFile} from '../coders/png-file';
-import {WAVFile} from '../coders/wav-file';
 
 class FakeZipFile {
     constructor (file) {
@@ -49,11 +48,7 @@ const toSb2ImageMedia = imageMedia => {
     return imageMedia.decoded;
 };
 
-const toSb2SoundMedia = soundMedia => (
-    new Uint8Array(WAVFile.encode(soundMedia.decoded, {
-        sampleRate: soundMedia.rate && soundMedia.rate.value
-    }))
-);
+const toSb2SoundMedia = soundMedia => soundMedia.wavEncodedData;
 
 const toSb2FakeZipApi = ({images, sounds}) => {
     const files = {};

--- a/src/to-sb2/json-generator.js
+++ b/src/to-sb2/json-generator.js
@@ -94,7 +94,7 @@ const toSb2Json = root => {
         return {
             soundName: soundMediaData.name,
             soundID,
-            md5: `${md5(soundMediaData.rawBytes)}.wav`,
+            md5: `${soundMediaData.md5}.wav`,
             sampleCount: soundMediaData.sampleCount,
             rate: soundMediaData.rate,
             format: ''


### PR DESCRIPTION
This fixes an issue where the md5 in the sb2 json was not matching the md5 from the assets server.
This fix avoids encoding the sound data as a wav twice.