### PR TITLE
fix: update to the latest text-encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1773,6 +1773,7 @@
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "dev": true,
+      "optional": true,
       "requires": {
         "define-properties": "^1.1.2",
         "es-abstract": "^1.7.0"
@@ -2824,7 +2825,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -4565,7 +4567,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
@@ -4594,6 +4597,7 @@
           "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -12979,9 +12983,9 @@
       }
     },
     "text-encoding": {
-      "version": "0.6.4",
-      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
+      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA=="
     },
     "text-extensions": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "semantic-release": "semantic-release"
   },
   "dependencies": {
+    "js-md5": "0.7.3",
     "minilog": "3.1.0",
-    "text-encoding": "^0.6.4",
-    "js-md5": "0.7.3"
+    "text-encoding": "^0.7.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.0",


### PR DESCRIPTION
### Resolves

Faster project loading and less memory usage.

### Proposed Changes

Update to latest text-encoding.

### Reason for Changes

scratch-gui depends on text-encoding@0.7.0. If scratch-sb1-converter depends on 0.6.4, gui has to build an extra copy of text-encoding, one for gui (and other modules using 0.7.0, like scratch-storage) and another for scratch-sb1-converter, and one for scratch-sb1-converter. This increases the size of the JS build and if text-encoding is used on a system that needs it, it will be evaluated twice and split up the work decreasing the change the JS VM optimizes the text-encoding implementation.
