### PR TITLE
refactor: replace text-encoding polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4182,6 +4182,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="
+    },
     "faye-websocket": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
@@ -13029,11 +13034,6 @@
         "read-pkg-up": "^4.0.0",
         "require-main-filename": "^1.0.1"
       }
-    },
-    "text-encoding": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
-      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA=="
     },
     "text-extensions": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "semantic-release": "semantic-release"
   },
   "dependencies": {
+    "fastestsmallesttextencoderdecoder": "^1.0.22",
     "js-md5": "0.7.3",
-    "minilog": "3.1.0",
-    "text-encoding": "^0.7.0"
+    "minilog": "3.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.0",

--- a/src/squeak/byte-primitives.js
+++ b/src/squeak/byte-primitives.js
@@ -1,4 +1,4 @@
-import {TextDecoder as JSTextDecoder} from 'text-encoding';
+import {TextDecoder as JSTextDecoder} from 'fastestsmallesttextencoderdecoder';
 
 import {assert} from '../util/assert';
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,6 @@ module.exports = {
         path: path.resolve(__dirname, 'playground'),
         libraryTarget: 'commonjs2'
     },
-    externals: ['text-encoding'],
     module: {
         rules: [{
             test: /\.js$/,


### PR DESCRIPTION
### Resolves

Towards https://github.com/LLK/scratch-gui/issues/6898

### Proposed Changes

This PR replaces the `text-encoding` package with `fastestsmallesttextencoderdecoder`.

### Reason for Changes

The `text-encoding` package has been deprecated by its maintainer, and also adds 500KB of encoding data for non-UTF-8 text. Because we're only using it to decode UTF-8, that 500KB is entirely unnecessary.

I'd heard you're not keen on accepting PRs for this repository in particular, but this change is small in scope and is easy to test (assuming you still have access to Legacy Edge).

Also of note is that third-party projects like [Snapinator](https://github.com/djsrv/snapinator) are using this package as well, and `text-encoding` now makes up a majority of *their* bundle size as well because of this dependency.

### Test Coverage

Must be tested manually.

Legacy Edge is the only browser without native support for the `TextDecoder` API, so it can be tested by opening a .sb1 project in Legacy Edge and ensuring it still works properly.
