### PR TITLE
fix: apply a fix for older files, that lack a field necessary for sb2…

### DIFF
--- a/src/to-sb2/json-generator.js
+++ b/src/to-sb2/json-generator.js
@@ -190,7 +190,8 @@ const toSb2Json = root => {
             direction: (Math.round(spriteData.rotationDegrees * 1e6) / 1e6) - 270,
             rotationStyle: spriteData.rotationStyle,
             isDraggable: spriteData.draggable,
-            indexInLibrary: stageData.spriteOrderInLibrary.indexOf(spriteData),
+            indexInLibrary: stageData.spriteOrderInLibrary ?
+                stageData.spriteOrderInLibrary.indexOf(spriteData) : -1,
             visible: spriteData.visible,
             spriteInfo: {}
         };

--- a/test/integration/valid.js
+++ b/test/integration/valid.js
@@ -3,7 +3,6 @@ const path = require('path');
 const test = require('tap').test;
 
 const {SB1File} = require('../..');
-const {toSb2Json} = require('../../src/to-sb2/json-generator');
 
 test('bouncing-music-balls', t => {
     const uri = path.resolve(__dirname, '../fixtures/valid/bouncing-music-balls.sb');
@@ -130,13 +129,8 @@ test('legacy projects without sprite library ordering', t => {
 
     delete stageData.fields[stageData.FIELDS.SPRITE_ORDER_IN_LIBRARY];
 
-    const json = toSb2Json({
-        info: sb1.info(),
-        stageData,
-        images: sb1.images(),
-        sounds: sb1.sounds()
-    });
+    const json = sb1.json;
 
-    t.equal(json.children[0].indexInLibrary, -1);
+    t.same(json.children.map(child => child.indexInLibrary), [-1]);
     t.end();
 });

--- a/test/integration/valid.js
+++ b/test/integration/valid.js
@@ -3,6 +3,7 @@ const path = require('path');
 const test = require('tap').test;
 
 const {SB1File} = require('../..');
+const {toSb2Json} = require('../../src/to-sb2/json-generator');
 
 test('bouncing-music-balls', t => {
     const uri = path.resolve(__dirname, '../fixtures/valid/bouncing-music-balls.sb');
@@ -119,5 +120,23 @@ test('ewe-and-me', t => {
     t.equal(json.videoAlpha, 0.5);
     t.type(json.info, Object);
 
+    t.end();
+});
+
+test('legacy projects without sprite library ordering', t => {
+    const uri = path.resolve(__dirname, '../fixtures/valid/default.sb');
+    const sb1 = new SB1File(fs.readFileSync(uri));
+    const stageData = sb1.data();
+
+    delete stageData.fields[stageData.FIELDS.SPRITE_ORDER_IN_LIBRARY];
+
+    const json = toSb2Json({
+        info: sb1.info(),
+        stageData,
+        images: sb1.images(),
+        sounds: sb1.sounds()
+    });
+
+    t.equal(json.children[0].indexInLibrary, -1);
     t.end();
 });


### PR DESCRIPTION
The purpose of this PR is to fix an issue with older projects not having a certain field, that in newer(sb2) project file versions is expected to be an array, hence an indexOf() crash.